### PR TITLE
Don't match unicode characters in interpolated variable names

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -321,7 +321,7 @@
 		"string-interp": {
 			"patterns": [
 				{
-					"match": "\\$((\\w+)|\\{([^{}]+)\\})",
+					"match": "\\$(([a-zA-Z0-9_]+)|\\{([^{}]+)\\})",
 					"captures": {
 						"2": {
 							"name": "variable.parameter.dart"


### PR DESCRIPTION
This mirrors [a fix](https://github.com/Dart-Code/Dart-Code/commit/03a19d7f40c35beaac64eaae86ce3eafed1c5dee) from Dart-Code for https://github.com/Dart-Code/Dart-Code/issues/2575.

Before, unicode characters were treated as valid in interpolated variable names:

![WeChate216463751653492a1ec45db890cf583](https://user-images.githubusercontent.com/24644183/85241223-ac195e00-b46d-11ea-9173-206e3476fc9d.png)

This made is seem like braces were required, but they are not:

![WeChat50ebba0060b5bfb3b4adfa2492c7cc74](https://user-images.githubusercontent.com/24644183/85241250-ca7f5980-b46d-11ea-81fb-b51b8ebf2ae0.png)
