### PR TITLE
Color "if"s in conditional imports/exports

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -37,6 +37,10 @@
 				{
 					"name": "keyword.other.import.dart",
 					"match": "\\b(as|show|hide)\\b"
+				},
+				{
+					"name": "keyword.control.dart",
+					"match": "\\b(if)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
This adds colour to the `if`s in conditional imports (previously they were white):

![Screenshot 2021-06-14 at 17 12 43](https://user-images.githubusercontent.com/1078012/121924662-06bd6100-cd34-11eb-9ef9-aff000f5164c.png)

I've marked them as "control keywords" to match the color of other `if`s in the program, although I'm not sure if that logic is entirely sound. Having them a different color to other `if`s looked a little odd (in this theme, control keywords are pink and other keywords blue).

(I've done the same [in LSP semantic tokens version](https://dart-review.googlesource.com/c/sdk/+/203560/) - we should keep them in-sync if we decide to change it here).

@devoncarew 