### PR TITLE
Reuse grammar inside interpolation expressions instead of just looking for `}`

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -325,15 +325,30 @@
 		"string-interp": {
 			"patterns": [
 				{
-					"match": "\\$(([a-zA-Z0-9_]+)|\\{([^{}]+)\\})",
+					"match": "\\$([a-zA-Z0-9_]+)",
 					"captures": {
-						"2": {
-							"name": "variable.parameter.dart"
-						},
-						"3": {
+						"1": {
 							"name": "variable.parameter.dart"
 						}
 					}
+				},
+				{
+					"name": "string.interpolated.expression.dart",
+					"begin": "\\$\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"include": "#constants-and-special-vars",
+							"name": "variable.parameter.dart"
+						},
+						{
+							"include": "#strings"
+						},
+						{
+							"name": "variable.parameter.dart",
+							"match": "[a-zA-Z0-9_]+"
+						}
+					]
 				},
 				{
 					"name": "constant.character.escape.dart",


### PR DESCRIPTION
In the existing grammar, interpolation expressions are detected by `${` and then end with `}`. This falls down if there are `}` inside the expression that are not the end of the interpolated part of the string.

This change instead reuses the other parts of the grammar to parse this code, so the correct `}` should be used (I don't know that it's 100% reliable, but it seems a significant improvement).

Left: before, right: after.

<img width="1196" alt="Screenshot 2021-07-19 at 14 35 09" src="https://user-images.githubusercontent.com/1078012/126169180-44572402-9cec-4675-968f-2408f21fa408.png">

Most of the code is orange because the `} `in the string on line 14 was being considered the end of the expression, and then the subsequent quote assumed to start a new string.

I had originally planned to just simplify the grammar by removing the colouring for interpolated expressions (to allow something like LSP Semantic Tokens to lay this on top for clients that support it), however even without colouring the expressions, it would've required knowing where the expression/string ended, so this seemed like a better solution.

@devoncarew 