### PR TITLE
Fix nested comment highlighting, colour if's in conditional imports, improve interpolated expressions

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -325,15 +325,30 @@
 		"string-interp": {
 			"patterns": [
 				{
-					"match": "\\$(([a-zA-Z0-9_]+)|\\{([^{}]+)\\})",
+					"match": "\\$([a-zA-Z0-9_]+)",
 					"captures": {
-						"2": {
-							"name": "variable.parameter.dart"
-						},
-						"3": {
+						"1": {
 							"name": "variable.parameter.dart"
 						}
 					}
+				},
+				{
+					"name": "string.interpolated.expression.dart",
+					"begin": "\\$\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"include": "#constants-and-special-vars",
+							"name": "variable.parameter.dart"
+						},
+						{
+							"include": "#strings"
+						},
+						{
+							"name": "variable.parameter.dart",
+							"match": "[a-zA-Z0-9_]+"
+						}
+					]
 				},
 				{
 					"name": "constant.character.escape.dart",

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -111,9 +111,6 @@
 							"name": "variable.other.source.dart"
 						}
 					}
-				},
-				{
-					"match": "(\\*    .*)$"
 				}
 			]
 		},

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -37,6 +37,10 @@
 				{
 					"name": "keyword.other.import.dart",
 					"match": "\\b(as|show|hide)\\b"
+				},
+				{
+					"name": "keyword.control.dart",
+					"match": "\\b(if)\\b"
 				}
 			]
 		},


### PR DESCRIPTION
This syncs with the latest Dart-Code syntax highlight file. It includes three fixes (two of which previously shipped in Dart-Code, and the last one is new today):

- Color `if`s in conditional imports
- Handle interpolated expressions better (by nesting rules to more reliably detect the end of the expression instead of assuming the first `}`)
  https://github.com/Dart-Code/Dart-Code/issues/2056
- Handle nested expressions better (don't eat any line that starts with `*    ` assuming it won't end a comment)
  https://github.com/Dart-Code/Dart-Code/issues/3546

I've compared the results across some test files and several large SDK files and the only differences I spotted are those the fixes are intended to address (screenshots in the linked issues above).