### PR TITLE
Improve handling of < and > in type arguments

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -222,16 +222,71 @@
 					"match": "(?<!\\$)\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)\\b(?!\\$)"
 				},
 				{
-					"name": "support.class.dart",
-					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*|bool\\b|num\\b|int\\b|double\\b|dynamic\\b)"
+					"include": "#class-identifier"
 				},
 				{
-					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<|\\(|\\s+=>)",
+					"include": "#function-identifier"
+				}
+
+			]
+		},
+		"class-identifier": {
+			"patterns": [
+				{
+					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>]|, )+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b)",
+					"captures": {
+						"1": {
+							"name": "support.class.dart"
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#type-args"
+								}
+							]
+						}
+					}
+				}
+			]
+		},
+		"function-identifier": {
+			"patterns": [
+				{
+					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>]|, )+>)?(\\(|\\s+=>)",
 					"captures": {
 						"1": {
 							"name": "entity.name.function.dart"
+						},
+						"2": {
+							"patterns": [
+								{
+									"include": "#type-args"
+								}
+							]
 						}
 					}
+				}
+			]
+		},
+		"type-args": {
+			"begin": "(<)",
+			"end": "(>)",
+			"beginCaptures": {
+				"1": {
+					"name": "other.source.dart"
+				}
+			},
+			"endCaptures": {
+				"1": {
+					"name": "other.source.dart"
+				}
+			},
+			"patterns": [
+				{
+					"include": "#class-identifier"
+				},
+				{
+					"match": "\\s*,\\s*"
 				}
 			]
 		},


### PR DESCRIPTION
The original grammar was detecting functions like this:

```
([_$]*[a-z][a-zA-Z0-9_$]*)(<|\\(|\\s+=>)
```

The last part says any identifier that is followed by `<`, `(` or `\s+=>` is a function. However it was also eating that character so it would be left uncoloured. For type args on functions, this meant the opening `<` would be uncoloured, but the normal colouring for greater-than/less-than operators would apply to the closing `>` leading to mismatched colours for some editor themes (though that apply colours to the operators that differ from uncoloured code).

This change tries to parse the type arguments specifically, and removes the operator colouring from them, so they should now appear consistently. I don't have a good way to automate verifying these changes (although there may be value in doing so at some point?) but I've manually checked a bunch of long files in Analyzer + Flutter and haven't noticed any changes beyond those intended.

Before/After.

<img width="1714" alt="Screenshot 2021-10-27 at 15 22 04" src="https://user-images.githubusercontent.com/1078012/139086295-39aeb8f0-c6e1-4eec-8432-05ccae4150b8.png">
