### PR TITLE
Fix colouring of "void" when used in type args

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -233,7 +233,7 @@
 		"class-identifier": {
 			"patterns": [
 				{
-					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>]|, )+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b)",
+					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>]|, )+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b|(void)\\b)",
 					"captures": {
 						"1": {
 							"name": "support.class.dart"
@@ -244,6 +244,9 @@
 									"include": "#type-args"
 								}
 							]
+						},
+						"3": {
+							"name": "storage.type.primitive.dart"
 						}
 					}
 				}


### PR DESCRIPTION
The change in #21 lost colouring on `void` in type args (since it needs special handling for types that start with lowercase letters) because it wasn't previously included (and was coloured by regex that wasn't specific to the type args):

// Before this change
![Screenshot 2021-10-28 at 13 32 19](https://user-images.githubusercontent.com/1078012/139256663-e81d775b-9b5d-4d5a-9871-b30df9558def.png)

// With this change (which matches the behaviour before #21)
![Screenshot 2021-10-28 at 13 32 29](https://user-images.githubusercontent.com/1078012/139256667-6b6c1014-88af-46c8-8013-fbd8a7e5aa9a.png)

For this syntax, `void` is coloured like a built-in rather than a class name (although with semantic tokens, it has a modifier so that can be overridden by users/editors if they choose).

@devoncarew 