### PR TITLE
Allow "extends" and "?" in type args

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -233,7 +233,7 @@
 		"class-identifier": {
 			"patterns": [
 				{
-					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>]|,\\s*|\\s+extends\\s+)+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b|(void)\\b)",
+					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b|(void)\\b)",
 					"captures": {
 						"1": {
 							"name": "support.class.dart"
@@ -255,7 +255,7 @@
 		"function-identifier": {
 			"patterns": [
 				{
-					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>]|,\\s*|\\s+extends\\s+)+>)?(\\(|\\s+=>)",
+					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?(\\(|\\s+=>)",
 					"captures": {
 						"1": {
 							"name": "entity.name.function.dart"

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -233,7 +233,7 @@
 		"class-identifier": {
 			"patterns": [
 				{
-					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>]|, )+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b|(void)\\b)",
+					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>]|,\\s*|\\s+extends\\s+)+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b|(void)\\b)",
 					"captures": {
 						"1": {
 							"name": "support.class.dart"
@@ -255,7 +255,7 @@
 		"function-identifier": {
 			"patterns": [
 				{
-					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>]|, )+>)?(\\(|\\s+=>)",
+					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>]|,\\s*|\\s+extends\\s+)+>)?(\\(|\\s+=>)",
 					"captures": {
 						"1": {
 							"name": "entity.name.function.dart"
@@ -289,7 +289,11 @@
 					"include": "#class-identifier"
 				},
 				{
-					"match": "\\s*,\\s*"
+					"match": "[\\s,]+"
+				},
+				{
+					"name": "keyword.declaration.dart",
+					"match": "extends"
 				}
 			]
 		},


### PR DESCRIPTION
The recent changes I made to handle type args better did not take into account `extends` inside the args, which resulted in the type args not being parsed at all, which caused the function expressions to fail to match:

<img width="672" alt="Screenshot 2021-11-08 at 14 34 54" src="https://user-images.githubusercontent.com/1078012/140760876-869dae68-c773-49bb-8975-5ab80c61fe2f.png">

Similar was true for `?` in nullable types inside type args. This change should handle both:

![Screenshot 2021-11-08 at 14 33 51](https://user-images.githubusercontent.com/1078012/140760757-e891c715-b5a2-4d80-a0f1-fe790c5e0b3d.png)

Most VS Code users wouldn't see this because semantic tokens would quickly be overlaid and fix it, but I'm trying to minimise the number of color changes when the semantic tokens become available.