### PR TITLE
Allow ? and ! in function before ( in function identifiers

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -255,7 +255,7 @@
 		"function-identifier": {
 			"patterns": [
 				{
-					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?(\\(|\\s+=>)",
+					"match": "([_$]*[a-z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?[!?]?(\\(|\\s+=>)",
 					"captures": {
 						"1": {
 							"name": "entity.name.function.dart"


### PR DESCRIPTION
This came up in https://github.com/Dart-Code/Dart-Code/issues/3888. Function invocations that have `?` or `!` were not being classified as functions. This change allows either of those to appear just before the `(` and still be treated as a function identifier.

### Before:

![Screenshot 2022-03-28 at 18 48 42](https://user-images.githubusercontent.com/1078012/160457804-3fab34d3-7337-407e-bbf4-ef95e331bcbd.png)

### After:

![Screenshot 2022-03-28 at 18 48 57](https://user-images.githubusercontent.com/1078012/160457810-f59bd2ea-8044-49ab-ae64-85153100d384.png)

(@devoncarew I'm not sure if someone suitable gets notifications of PRs here, if they are and shouldn't ping you, lmk!)