### PR TITLE
Add some basic testing using some test files and a golden text representation of tokens

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  PUB_ENVIRONMENT: bot.github
+
 jobs:
   build:
 
@@ -27,3 +30,5 @@ jobs:
       run: dart analyze
     - name: Verify grammar file
       run: dart run tool/verify.dart
+    - name: Test
+      run: dart test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# How to Contribute
+
+For license agreement and CLA information, contribution workflow information, code reviews, code style, and community guidelines, please see <https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md>.
+
+
+# Adding Tests for Changes
+
+In the `test/test_files` folder are a set of `.dart` files that are parsed using the grammar. Text representations of the results are stored in `test/goldens` and verified by tests. If your changes to the grammar affect the output you will need to regenerate the golden files and commit them to pass the bots.
+
+If the existing test files do not already include sample code that covers the changes you are making, you should add new examples first. Regenerating and committing the new examples and updated golden files _before_ making grammar changes will make your changes easier to review, since the PR will then contain a snapshot of both before and after:
+
+1. Add new sample code to `test/test_files` if required
+1. Regenerate golden files
+1. Commit changes to your branch
+1. Make grammar changes
+1. Regenerate golden files
+1. Commit changes to your branch
+
+## Regenerating Goldens
+
+To regenerate the golden files, run:
+
+```
+UPDATE_GOLDENS=true dart test
+```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - test/test_files

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,10 @@
 name: dart_syntax_highlight
 publish_to: none
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.14.0 <3.0.0'
 
-#dependencies:
+dev_dependencies:
+  collection: ^1.16.0
+  path: ^1.8.2
+  string_scanner: ^1.1.1
+  test: ^1.21.4

--- a/test/golden_test.dart
+++ b/test/golden_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:collection/collection.dart';
+import 'package:path/path.dart' as path;
+
+import 'support/span_parser.dart';
+
+void main() {
+  final projectRoot = path.normalize(
+    path.join(path.basename(Platform.script.toFilePath()), '..'),
+  );
+  final testFileDirectory =
+      Directory(path.join(projectRoot, 'test', 'test_files'));
+  final goldenDirectory = Directory(path.join(projectRoot, 'test', 'goldens'));
+  final grammarFile = File(path.join(projectRoot, 'grammars/dart.json'));
+  final grammar = Grammar.fromJson(jsonDecode(grammarFile.readAsStringSync()));
+  final updateGoldens = Platform.environment.containsKey('UPDATE_GOLDENS');
+
+  group('golden', () {
+    final testFiles = testFileDirectory
+        .listSync()
+        .whereType<File>()
+        .where((file) => path.extension(file.path) == '.dart');
+
+    for (final testFile in testFiles) {
+      final goldenFile = File(path.join(
+        goldenDirectory.path,
+        '${path.basename(testFile.path)}.golden',
+      ));
+      test(path.basename(testFile.path), () {
+        if (!goldenFile.existsSync() && !updateGoldens) {
+          fail('Missing golden file: ${goldenFile.path}');
+        }
+
+        final content = testFile.readAsStringSync();
+        final spans = SpanParser.parse(grammar, content);
+        final actual = _buildGoldenText(content, spans);
+
+        if (updateGoldens) {
+          goldenFile.writeAsStringSync(actual);
+        } else {
+          final expected = goldenFile.readAsStringSync();
+          expect(_normalize(actual), _normalize(expected));
+        }
+      });
+    }
+  });
+}
+
+String _buildGoldenText(String content, List<ScopeSpan> spans) {
+  final buffer = StringBuffer();
+  final spansByLine = groupBy(spans, (ScopeSpan s) => s.line - 1);
+
+  final lines = content.trim().split('\n');
+  for (var i = 0; i < lines.length; i++) {
+    final line = lines[i];
+    // We need the line length to wrap. If this isn't the last line, account for
+    // the \n we split by.
+    final newlineLength = (i == lines.length - 1) ? 0 : 1;
+    final lineLengthWithNewline = line.length + newlineLength;
+
+    buffer.writeln('>$line');
+    final lineSpans = spansByLine[i];
+    if (lineSpans != null) {
+      for (final span in lineSpans) {
+        final col = span.column - 1;
+        var length = span.length;
+
+        // Spans may roll over onto the next line, so truncate them and insert
+        // the remainder into the next.
+        if (col + length > lineLengthWithNewline) {
+          final thisLineLength = line.length - col;
+          final offsetToStartOfNextLine = lineLengthWithNewline - col;
+          length = thisLineLength;
+          spansByLine[i + 1] ??= [];
+          // Insert the wrapped span before other spans on the next line so the
+          // order is preserved.
+          spansByLine[i + 1]!.insert(
+            0,
+            ScopeSpan(
+              scopes: span.scopes,
+              startLocation: ScopeStackLocation(
+                position: span.start + offsetToStartOfNextLine,
+                line: span.line + 1,
+                column: 0,
+              ),
+              endLocation: span.endLocation,
+            ),
+          );
+        } else if (col + length > line.length) {
+          // Truncate any spans that include the trailing newline.
+          length = line.length - col;
+        }
+
+        // If this span just covers the trailing newline, skip it
+        // as it doesn't produce any useful output.
+        if (col == line.length) {
+          continue;
+        }
+
+        buffer.write('#');
+        buffer.write(' ' * col);
+        buffer.write('^' * length);
+        buffer.write(' ');
+        buffer.writeln(span.scopes.join(' '));
+      }
+    }
+  }
+
+  return buffer.toString();
+}
+
+/// Normalises newlines in code for comparing.
+String _normalize(String code) => code.replaceAll('\r', '');

--- a/test/goldens/classes.dart.golden
+++ b/test/goldens/classes.dart.golden
@@ -1,0 +1,123 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>class Class1 {}
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^ support.class.dart
+>
+>abstract class Class2 implements Class1 {
+#^^^^^^^^ keyword.declaration.dart
+#         ^^^^^ keyword.declaration.dart
+#               ^^^^^^ support.class.dart
+#                      ^^^^^^^^^^ keyword.declaration.dart
+#                                 ^^^^^^ support.class.dart
+>  String get a;
+#  ^^^^^^ support.class.dart
+#         ^^^ keyword.declaration.dart
+#              ^ punctuation.terminator.dart
+>  set a(String value);
+#  ^^^ keyword.declaration.dart
+#      ^ entity.name.function.dart
+#        ^^^^^^ support.class.dart
+#                     ^ punctuation.terminator.dart
+>}
+>
+>class Class3 extends Class2 with MyMixin {
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^ support.class.dart
+#             ^^^^^^^ keyword.declaration.dart
+#                     ^^^^^^ support.class.dart
+#                            ^^^^ keyword.declaration.dart
+#                                 ^^^^^^^ support.class.dart
+>  @override
+#  ^^^^^^^^^ storage.type.annotation.dart
+>  String get a => '';
+#  ^^^^^^ support.class.dart
+#         ^^^ keyword.declaration.dart
+#             ^ entity.name.function.dart
+#                  ^^ string.interpolated.single.dart
+#                    ^ punctuation.terminator.dart
+>
+>  @override
+#  ^^^^^^^^^ storage.type.annotation.dart
+>  set a(String value) {}
+#  ^^^ keyword.declaration.dart
+#      ^ entity.name.function.dart
+#        ^^^^^^ support.class.dart
+>
+>  void method() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^^^^ entity.name.function.dart
+>}
+>
+>class Class4<T extends Class2> implements Class1 {}
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^ support.class.dart
+#            ^ other.source.dart
+#             ^ support.class.dart
+#               ^^^^^^^ keyword.declaration.dart
+#                       ^^^^^^ support.class.dart
+#                             ^ other.source.dart
+#                               ^^^^^^^^^^ keyword.declaration.dart
+#                                          ^^^^^^ support.class.dart
+>
+>class MyClass {
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^^ support.class.dart
+>  void method1() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^^^^^ entity.name.function.dart
+>  void Method2() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^^^^^ support.class.dart
+>  void get() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^ keyword.declaration.dart
+>  void set() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^ keyword.declaration.dart
+>
+>  String? _foo;
+#  ^^^^^^ support.class.dart
+#        ^ keyword.operator.ternary.dart
+#              ^ punctuation.terminator.dart
+>  String? get foo => _foo;
+#  ^^^^^^ support.class.dart
+#        ^ keyword.operator.ternary.dart
+#          ^^^ keyword.declaration.dart
+#              ^^^ entity.name.function.dart
+#                         ^ punctuation.terminator.dart
+>  set foo(String? value) => _foo = value;
+#  ^^^ keyword.declaration.dart
+#      ^^^ entity.name.function.dart
+#          ^^^^^^ support.class.dart
+#                ^ keyword.operator.ternary.dart
+#                         ^^ keyword.operator.closure.dart
+#                                 ^ keyword.operator.assignment.dart
+#                                        ^ punctuation.terminator.dart
+>}
+>
+>mixin MyMixin {}
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^^ support.class.dart
+>
+>mixin MyMixin2 on Class1 {}
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^^^ support.class.dart
+#               ^^ keyword.control.catch-exception.dart
+#                  ^^^^^^ support.class.dart
+>
+>extension on String {}
+#^^^^^^^^^ keyword.declaration.dart
+#          ^^ keyword.control.catch-exception.dart
+#             ^^^^^^ support.class.dart
+>
+>extension StringExtension on String {}
+#^^^^^^^^^ keyword.declaration.dart
+#          ^^^^^^^^^^^^^^^ support.class.dart
+#                          ^^ keyword.control.catch-exception.dart
+#                             ^^^^^^ support.class.dart

--- a/test/goldens/classes.dart.golden
+++ b/test/goldens/classes.dart.golden
@@ -121,3 +121,55 @@
 #          ^^^^^^^^^^^^^^^ support.class.dart
 #                          ^^ keyword.control.catch-exception.dart
 #                             ^^^^^^ support.class.dart
+>
+>extension StringListExtension on List<String> {}
+#^^^^^^^^^ keyword.declaration.dart
+#          ^^^^^^^^^^^^^^^^^^^ support.class.dart
+#                              ^^ keyword.control.catch-exception.dart
+#                                 ^^^^ support.class.dart
+#                                     ^ other.source.dart
+#                                      ^^^^^^ support.class.dart
+#                                            ^ other.source.dart
+>
+>extension<T extends String> on T {}
+#^^^^^^^^^ keyword.declaration.dart
+#         ^ keyword.operator.comparison.dart
+#          ^ support.class.dart
+#            ^^^^^^^ keyword.declaration.dart
+#                    ^^^^^^ support.class.dart
+#                          ^ keyword.operator.comparison.dart
+#                            ^^ keyword.control.catch-exception.dart
+#                               ^ support.class.dart
+>
+>class my_lowercase_class {
+#^^^^^ keyword.declaration.dart
+>  my_lowercase_class? foo() => null;
+#                    ^ keyword.operator.ternary.dart
+#                      ^^^ entity.name.function.dart
+#                            ^^ keyword.operator.closure.dart
+#                               ^^^^ constant.language.dart
+#                                   ^ punctuation.terminator.dart
+>  List<my_lowercase_class>? bar() => null;
+#  ^^^^ support.class.dart
+#      ^ other.source.dart
+#                         ^ other.source.dart
+#                          ^ keyword.operator.ternary.dart
+#                            ^^^ entity.name.function.dart
+#                                  ^^ keyword.operator.closure.dart
+#                                     ^^^^ constant.language.dart
+#                                         ^ punctuation.terminator.dart
+>}
+>
+>class A1<T> {}
+#^^^^^ keyword.declaration.dart
+#      ^^ support.class.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#          ^ other.source.dart
+>
+>class A2<T> extends A1<T> {}
+#^^^^^ keyword.declaration.dart
+#      ^^ support.class.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#          ^ other.source.dart

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -1,0 +1,104 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>/// Multiline dartdoc comment.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>/// ```
+#^^^^^^^ comment.block.documentation.dart
+>/// doc
+#^^^ comment.block.documentation.dart
+#   ^^^^ comment.block.documentation.dart variable.other.source.dart
+>/// ```
+#^^^ comment.block.documentation.dart
+#   ^ comment.block.documentation.dart variable.other.source.dart
+#    ^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>/// ...
+#^^^^^^^ comment.block.documentation.dart
+>var a;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>/*
+#^^ comment.block.dart
+> * Old-style dartdoc
+#^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+> *
+#^^ comment.block.dart
+> * ...
+#^^^^^^ comment.block.dart
+> */
+#^^^ comment.block.dart
+>var b;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>/* Inline block comment */
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+>var c;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>/**
+#^^^ comment.block.documentation.dart
+> * Nested block
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart
+> *
+#^^ comment.block.documentation.dart
+> * /**
+#^^^^^^ comment.block.documentation.dart
+> *  * Nested block
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+> *  */
+#^^^^^^ comment.block.documentation.dart
+> */
+#^^^ comment.block.documentation.dart
+>var d;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>/**
+#^^^ comment.block.documentation.dart
+> * Nested
+#^^^^^^^^^ comment.block.documentation.dart
+> *
+#^^ comment.block.documentation.dart
+> * /* Inline */
+#^^^ comment.block.documentation.dart
+#   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
+> */
+#^^^ comment.block.documentation.dart
+>var e;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>/* Nested /* Inline */ */
+#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+>var f;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>// Simple comment
+#^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>var g;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
+>
+>/// Dartdoc with reference to [a].
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#                              ^^^ comment.block.documentation.dart variable.name.source.dart
+#                                 ^ comment.block.documentation.dart
+>/// And a link to [example.org](http://example.org/).
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
+#                               ^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>var h;
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart

--- a/test/goldens/control.dart.golden
+++ b/test/goldens/control.dart.golden
@@ -1,0 +1,118 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>void err() {
+#^^^^ storage.type.primitive.dart
+#     ^^^ entity.name.function.dart
+>  try {
+#  ^^^ keyword.control.catch-exception.dart
+>    throw '';
+#    ^^^^^ keyword.control.catch-exception.dart
+#          ^^ string.interpolated.single.dart
+#            ^ punctuation.terminator.dart
+>  } on ArgumentError {
+#    ^^ keyword.control.catch-exception.dart
+#       ^^^^^^^^^^^^^ support.class.dart
+>    rethrow;
+#    ^^^^^^^ keyword.control.catch-exception.dart
+#           ^ punctuation.terminator.dart
+>  } catch (e) {
+#    ^^^^^ keyword.control.catch-exception.dart
+>    print('e');
+#    ^^^^^ entity.name.function.dart
+#          ^^^ string.interpolated.single.dart
+#              ^ punctuation.terminator.dart
+>  }
+>}
+>
+>void loops() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^ entity.name.function.dart
+>  while (1 > 2) {
+#  ^^^^^ keyword.control.dart
+#         ^ constant.numeric.dart
+#           ^ keyword.operator.comparison.dart
+#             ^ constant.numeric.dart
+>    if (3 > 4) {
+#    ^^ keyword.control.dart
+#        ^ constant.numeric.dart
+#          ^ keyword.operator.comparison.dart
+#            ^ constant.numeric.dart
+>      continue;
+#      ^^^^^^^^ keyword.control.dart
+#              ^ punctuation.terminator.dart
+>    } else {
+#      ^^^^ keyword.control.dart
+>      break;
+#      ^^^^^ keyword.control.dart
+#           ^ punctuation.terminator.dart
+>    }
+>    return;
+#    ^^^^^^ keyword.control.dart
+#          ^ punctuation.terminator.dart
+>  }
+>
+>  do {
+#  ^^ keyword.control.dart
+>    print('');
+#    ^^^^^ entity.name.function.dart
+#          ^^ string.interpolated.single.dart
+#             ^ punctuation.terminator.dart
+>  } while (1 > 2);
+#    ^^^^^ keyword.control.dart
+#           ^ constant.numeric.dart
+#             ^ keyword.operator.comparison.dart
+#               ^ constant.numeric.dart
+#                 ^ punctuation.terminator.dart
+>}
+>
+>void switches() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^^ entity.name.function.dart
+>  Object? i = 1;
+#  ^^^^^^ support.class.dart
+#        ^ keyword.operator.ternary.dart
+#            ^ keyword.operator.assignment.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>  switch (i as int) {
+#  ^^^^^^ keyword.control.dart
+#            ^^ keyword.cast.dart
+#               ^^^ support.class.dart
+>    case 1:
+#    ^^^^ keyword.control.dart
+#         ^ constant.numeric.dart
+#          ^ keyword.operator.ternary.dart
+>      break;
+#      ^^^^^ keyword.control.dart
+#           ^ punctuation.terminator.dart
+>    default:
+#    ^^^^^^^ keyword.control.dart
+#           ^ keyword.operator.ternary.dart
+>      return;
+#      ^^^^^^ keyword.control.dart
+#            ^ punctuation.terminator.dart
+>  }
+>}
+>
+>void conditions() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^^^^ entity.name.function.dart
+>  if (1 > 2) {
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^ keyword.operator.comparison.dart
+#          ^ constant.numeric.dart
+>  } else if (3 > 4) {
+#    ^^^^ keyword.control.dart
+#         ^^ keyword.control.dart
+#             ^ constant.numeric.dart
+#               ^ keyword.operator.comparison.dart
+#                 ^ constant.numeric.dart
+>  } else {}
+#    ^^^^ keyword.control.dart
+>}

--- a/test/goldens/directives.dart.golden
+++ b/test/goldens/directives.dart.golden
@@ -1,0 +1,72 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>import 'dart:io';
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart punctuation.terminator.dart
+>import 'dart:io' as io;
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart
+#                 ^^ meta.declaration.dart keyword.other.import.dart
+#                   ^^^ meta.declaration.dart
+#                      ^ meta.declaration.dart punctuation.terminator.dart
+>import 'dart:io' show File;
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart
+#                 ^^^^ meta.declaration.dart keyword.other.import.dart
+#                     ^^^^^ meta.declaration.dart
+#                          ^ meta.declaration.dart punctuation.terminator.dart
+>import 'dart:io' hide Directory;
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart
+#                 ^^^^ meta.declaration.dart keyword.other.import.dart
+#                     ^^^^^^^^^^ meta.declaration.dart
+#                               ^ meta.declaration.dart punctuation.terminator.dart
+>import 'dart:io' show File hide Directory;
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart
+#                 ^^^^ meta.declaration.dart keyword.other.import.dart
+#                     ^^^^^^ meta.declaration.dart
+#                           ^^^^ meta.declaration.dart keyword.other.import.dart
+#                               ^^^^^^^^^^ meta.declaration.dart
+#                                         ^ meta.declaration.dart punctuation.terminator.dart
+>import 'dart:io' as io show Directory;
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart
+#                 ^^ meta.declaration.dart keyword.other.import.dart
+#                   ^^^^ meta.declaration.dart
+#                       ^^^^ meta.declaration.dart keyword.other.import.dart
+#                           ^^^^^^^^^^ meta.declaration.dart
+#                                     ^ meta.declaration.dart punctuation.terminator.dart
+>import 'dart:async' deferred as deferredAsync show Future;
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                   ^^^^^^^^^^ meta.declaration.dart
+#                             ^^ meta.declaration.dart keyword.other.import.dart
+#                               ^^^^^^^^^^^^^^^ meta.declaration.dart
+#                                              ^^^^ meta.declaration.dart keyword.other.import.dart
+#                                                  ^^^^^^^ meta.declaration.dart
+#                                                         ^ meta.declaration.dart punctuation.terminator.dart
+>
+>export 'comments.dart';
+#^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
+#       ^^^^^^^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                      ^ meta.declaration.dart punctuation.terminator.dart

--- a/test/goldens/functions.dart.golden
+++ b/test/goldens/functions.dart.golden
@@ -150,3 +150,17 @@
 #         ^^^^^^^^^^ entity.name.function.dart
 #                     ^ punctuation.terminator.dart
 >}
+>
+>T foo<T extends String>(String a) => throw UnimplementedError();
+#^ support.class.dart
+#  ^^^ entity.name.function.dart
+#     ^ other.source.dart
+#      ^ support.class.dart
+#        ^^^^^^^ keyword.declaration.dart
+#                ^^^^^^ support.class.dart
+#                      ^ other.source.dart
+#                        ^^^^^^ support.class.dart
+#                                  ^^ keyword.operator.closure.dart
+#                                     ^^^^^ keyword.control.catch-exception.dart
+#                                           ^^^^^^^^^^^^^^^^^^ support.class.dart
+#                                                               ^ punctuation.terminator.dart

--- a/test/goldens/functions.dart.golden
+++ b/test/goldens/functions.dart.golden
@@ -1,0 +1,152 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>void simplePrint() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^^^^^ entity.name.function.dart
+>  print('hello world');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^ string.interpolated.single.dart
+#                      ^ punctuation.terminator.dart
+>}
+>
+>noReturnValue() {
+#^^^^^^^^^^^^^ entity.name.function.dart
+>  print('hello world');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^ string.interpolated.single.dart
+#                      ^ punctuation.terminator.dart
+>}
+>
+>void returns() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^ entity.name.function.dart
+>  return;
+#  ^^^^^^ keyword.control.dart
+#        ^ punctuation.terminator.dart
+>}
+>
+>Future<void> asyncPrint() async {
+#^^^^^^ support.class.dart
+#      ^ other.source.dart
+#       ^^^^ storage.type.primitive.dart
+#           ^ other.source.dart
+#             ^^^^^^^^^^ entity.name.function.dart
+#                          ^^^^^ keyword.control.dart
+>  await Future.delayed(const Duration(seconds: 1));
+#  ^^^^^ keyword.control.dart
+#        ^^^^^^ support.class.dart
+#              ^ punctuation.dot.dart
+#               ^^^^^^^ entity.name.function.dart
+#                       ^^^^^ storage.modifier.dart
+#                             ^^^^^^^^ support.class.dart
+#                                             ^ keyword.operator.ternary.dart
+#                                               ^ constant.numeric.dart
+#                                                  ^ punctuation.terminator.dart
+>  print('hello world');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^ string.interpolated.single.dart
+#                      ^ punctuation.terminator.dart
+>}
+>
+>Map<T1, List<T2>> nestedGenerics<T1, T2 extends String>() {
+#^^^ support.class.dart
+#   ^ other.source.dart
+#    ^^ support.class.dart
+#        ^^^^ support.class.dart
+#            ^ other.source.dart
+#             ^^ support.class.dart
+#               ^ other.source.dart
+#                  ^^^^^^^^^^^^^^ entity.name.function.dart
+#                                ^ other.source.dart
+#                                 ^^ support.class.dart
+#                                     ^^ support.class.dart
+#                                        ^^^^^^^ keyword.declaration.dart
+#                                                ^^^^^^ support.class.dart
+#                                                      ^ other.source.dart
+>  return {};
+#  ^^^^^^ keyword.control.dart
+#           ^ punctuation.terminator.dart
+>}
+>
+>Iterable<String> syncYield() sync* {
+#^^^^^^^^ support.class.dart
+#        ^ other.source.dart
+#         ^^^^^^ support.class.dart
+#               ^ other.source.dart
+#                 ^^^^^^^^^ entity.name.function.dart
+#                             ^^^^ keyword.control.dart
+#                                 ^ keyword.operator.arithmetic.dart
+>  yield '';
+#  ^^^^^ keyword.control.dart
+#        ^^ string.interpolated.single.dart
+#          ^ punctuation.terminator.dart
+>}
+>
+>Iterable<String> syncYieldStar() sync* {
+#^^^^^^^^ support.class.dart
+#        ^ other.source.dart
+#         ^^^^^^ support.class.dart
+#               ^ other.source.dart
+#                 ^^^^^^^^^^^^^ entity.name.function.dart
+#                                 ^^^^ keyword.control.dart
+#                                     ^ keyword.operator.arithmetic.dart
+>  yield* syncYield();
+#  ^^^^^ keyword.control.dart
+#       ^ keyword.operator.arithmetic.dart
+#         ^^^^^^^^^ entity.name.function.dart
+#                    ^ punctuation.terminator.dart
+>}
+>
+>Stream<String> asyncYield() async* {
+#^^^^^^ support.class.dart
+#      ^ other.source.dart
+#       ^^^^^^ support.class.dart
+#             ^ other.source.dart
+#               ^^^^^^^^^^ entity.name.function.dart
+#                            ^^^^^ keyword.control.dart
+#                                 ^ keyword.operator.arithmetic.dart
+>  await Future.delayed(const Duration(seconds: 1));
+#  ^^^^^ keyword.control.dart
+#        ^^^^^^ support.class.dart
+#              ^ punctuation.dot.dart
+#               ^^^^^^^ entity.name.function.dart
+#                       ^^^^^ storage.modifier.dart
+#                             ^^^^^^^^ support.class.dart
+#                                             ^ keyword.operator.ternary.dart
+#                                               ^ constant.numeric.dart
+#                                                  ^ punctuation.terminator.dart
+>  yield '';
+#  ^^^^^ keyword.control.dart
+#        ^^ string.interpolated.single.dart
+#          ^ punctuation.terminator.dart
+>}
+>
+>Stream<String> asyncYieldStar() async* {
+#^^^^^^ support.class.dart
+#      ^ other.source.dart
+#       ^^^^^^ support.class.dart
+#             ^ other.source.dart
+#               ^^^^^^^^^^^^^^ entity.name.function.dart
+#                                ^^^^^ keyword.control.dart
+#                                     ^ keyword.operator.arithmetic.dart
+>  await Future.delayed(const Duration(seconds: 1));
+#  ^^^^^ keyword.control.dart
+#        ^^^^^^ support.class.dart
+#              ^ punctuation.dot.dart
+#               ^^^^^^^ entity.name.function.dart
+#                       ^^^^^ storage.modifier.dart
+#                             ^^^^^^^^ support.class.dart
+#                                             ^ keyword.operator.ternary.dart
+#                                               ^ constant.numeric.dart
+#                                                  ^ punctuation.terminator.dart
+>  yield* asyncYield();
+#  ^^^^^ keyword.control.dart
+#       ^ keyword.operator.arithmetic.dart
+#         ^^^^^^^^^^ entity.name.function.dart
+#                     ^ punctuation.terminator.dart
+>}

--- a/test/goldens/literals.dart.golden
+++ b/test/goldens/literals.dart.golden
@@ -1,0 +1,111 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>const a = 'aaaaa';
+#^^^^^ storage.modifier.dart
+#        ^ keyword.operator.assignment.dart
+#          ^^^^^^^ string.interpolated.single.dart
+#                 ^ punctuation.terminator.dart
+>
+>const list1 = [];
+#^^^^^ storage.modifier.dart
+#            ^ keyword.operator.assignment.dart
+#                ^ punctuation.terminator.dart
+>const list2 = <String>[];
+#^^^^^ storage.modifier.dart
+#            ^ keyword.operator.assignment.dart
+#              ^ keyword.operator.comparison.dart
+#               ^^^^^^ support.class.dart
+#                     ^ keyword.operator.comparison.dart
+#                        ^ punctuation.terminator.dart
+>const list3 = ['', '$a'];
+#^^^^^ storage.modifier.dart
+#            ^ keyword.operator.assignment.dart
+#               ^^ string.interpolated.single.dart
+#                 ^ punctuation.comma.dart
+#                   ^^ string.interpolated.single.dart
+#                     ^ string.interpolated.single.dart variable.parameter.dart
+#                      ^ string.interpolated.single.dart
+#                        ^ punctuation.terminator.dart
+>const list4 = <String>['', '$a'];
+#^^^^^ storage.modifier.dart
+#            ^ keyword.operator.assignment.dart
+#              ^ keyword.operator.comparison.dart
+#               ^^^^^^ support.class.dart
+#                     ^ keyword.operator.comparison.dart
+#                       ^^ string.interpolated.single.dart
+#                         ^ punctuation.comma.dart
+#                           ^^ string.interpolated.single.dart
+#                             ^ string.interpolated.single.dart variable.parameter.dart
+#                              ^ string.interpolated.single.dart
+#                                ^ punctuation.terminator.dart
+>
+>const set1 = {};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#               ^ punctuation.terminator.dart
+>const set2 = <String>{};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^ keyword.operator.comparison.dart
+#              ^^^^^^ support.class.dart
+#                    ^ keyword.operator.comparison.dart
+#                       ^ punctuation.terminator.dart
+>const set3 = {'', '$a'};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#              ^^ string.interpolated.single.dart
+#                ^ punctuation.comma.dart
+#                  ^^ string.interpolated.single.dart
+#                    ^ string.interpolated.single.dart variable.parameter.dart
+#                     ^ string.interpolated.single.dart
+#                       ^ punctuation.terminator.dart
+>const set4 = <String>{'', '$a'};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^ keyword.operator.comparison.dart
+#              ^^^^^^ support.class.dart
+#                    ^ keyword.operator.comparison.dart
+#                      ^^ string.interpolated.single.dart
+#                        ^ punctuation.comma.dart
+#                          ^^ string.interpolated.single.dart
+#                            ^ string.interpolated.single.dart variable.parameter.dart
+#                             ^ string.interpolated.single.dart
+#                               ^ punctuation.terminator.dart
+>
+>const map1 = <String, String>{};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^ keyword.operator.comparison.dart
+#              ^^^^^^ support.class.dart
+#                    ^ punctuation.comma.dart
+#                      ^^^^^^ support.class.dart
+#                            ^ keyword.operator.comparison.dart
+#                               ^ punctuation.terminator.dart
+>const map2 = {'': '$a'};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#              ^^ string.interpolated.single.dart
+#                ^ keyword.operator.ternary.dart
+#                  ^^ string.interpolated.single.dart
+#                    ^ string.interpolated.single.dart variable.parameter.dart
+#                     ^ string.interpolated.single.dart
+#                       ^ punctuation.terminator.dart
+>const map3 = <String, String>{'': '$a'};
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^ keyword.operator.comparison.dart
+#              ^^^^^^ support.class.dart
+#                    ^ punctuation.comma.dart
+#                      ^^^^^^ support.class.dart
+#                            ^ keyword.operator.comparison.dart
+#                              ^^ string.interpolated.single.dart
+#                                ^ keyword.operator.ternary.dart
+#                                  ^^ string.interpolated.single.dart
+#                                    ^ string.interpolated.single.dart variable.parameter.dart
+#                                     ^ string.interpolated.single.dart
+#                                       ^ punctuation.terminator.dart

--- a/test/goldens/misc.dart.golden
+++ b/test/goldens/misc.dart.golden
@@ -1,0 +1,119 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>library foo;
+#^^^^^^^ meta.declaration.dart keyword.other.import.dart
+#       ^^^^ meta.declaration.dart
+#           ^ meta.declaration.dart punctuation.terminator.dart
+>
+>external int get externalInt;
+#^^^^^^^^ keyword.declaration.dart
+#         ^^^ support.class.dart
+#             ^^^ keyword.declaration.dart
+#                            ^ punctuation.terminator.dart
+>
+>typedef StringAlias = String;
+#^^^^^^^ keyword.declaration.dart
+#        ^^^^^^^^^^^ support.class.dart
+#                    ^ keyword.operator.assignment.dart
+#                      ^^^^^^ support.class.dart
+#                            ^ punctuation.terminator.dart
+>typedef void FunctionAlias1(String a, String b);
+#^^^^^^^ keyword.declaration.dart
+#        ^^^^ storage.type.primitive.dart
+#             ^^^^^^^^^^^^^^ support.class.dart
+#                            ^^^^^^ support.class.dart
+#                                    ^ punctuation.comma.dart
+#                                      ^^^^^^ support.class.dart
+#                                               ^ punctuation.terminator.dart
+>typedef FunctionAlias2 = void Function(String a, String b);
+#^^^^^^^ keyword.declaration.dart
+#        ^^^^^^^^^^^^^^ support.class.dart
+#                       ^ keyword.operator.assignment.dart
+#                         ^^^^ storage.type.primitive.dart
+#                              ^^^^^^^^ support.class.dart
+#                                       ^^^^^^ support.class.dart
+#                                               ^ punctuation.comma.dart
+#                                                 ^^^^^^ support.class.dart
+#                                                          ^ punctuation.terminator.dart
+>
+>void misc(int a, {required int b}) {
+#^^^^ storage.type.primitive.dart
+#     ^^^^ entity.name.function.dart
+#          ^^^ support.class.dart
+#               ^ punctuation.comma.dart
+#                  ^^^^^^^^ storage.modifier.dart
+#                           ^^^ support.class.dart
+>  assert(true);
+#  ^^^^^^ keyword.control.dart
+#         ^^^^ constant.language.dart
+#              ^ punctuation.terminator.dart
+>  assert(1 == 1, 'fail');
+#  ^^^^^^ keyword.control.dart
+#         ^ constant.numeric.dart
+#           ^^ keyword.operator.comparison.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.comma.dart
+#                 ^^^^^^ string.interpolated.single.dart
+#                        ^ punctuation.terminator.dart
+>
+>  var a = new String.fromCharCode(1);
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^^^ keyword.control.new.dart
+#              ^^^^^^ support.class.dart
+#                    ^ punctuation.dot.dart
+#                     ^^^^^^^^^^^^ entity.name.function.dart
+#                                  ^ constant.numeric.dart
+#                                    ^ punctuation.terminator.dart
+>  const b = int.fromEnvironment('');
+#  ^^^^^ storage.modifier.dart
+#          ^ keyword.operator.assignment.dart
+#            ^^^ support.class.dart
+#               ^ punctuation.dot.dart
+#                ^^^^^^^^^^^^^^^ entity.name.function.dart
+#                                ^^ string.interpolated.single.dart
+#                                   ^ punctuation.terminator.dart
+>  final c = '';
+#  ^^^^^ storage.modifier.dart
+#          ^ keyword.operator.assignment.dart
+#            ^^ string.interpolated.single.dart
+#              ^ punctuation.terminator.dart
+>  late final d = '';
+#  ^^^^ storage.modifier.dart
+#       ^^^^^ storage.modifier.dart
+#               ^ keyword.operator.assignment.dart
+#                 ^^ string.interpolated.single.dart
+#                   ^ punctuation.terminator.dart
+>  print(d is String);
+#  ^^^^^ entity.name.function.dart
+#          ^^ keyword.operator.dart
+#             ^^^^^^ support.class.dart
+#                    ^ punctuation.terminator.dart
+>  print(d is! String);
+#  ^^^^^ entity.name.function.dart
+#          ^^ keyword.operator.dart
+#            ^ keyword.operator.logical.dart
+#              ^^^^^^ support.class.dart
+#                     ^ punctuation.terminator.dart
+>}
+>
+>class Covariance<T> {
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^^^^^ support.class.dart
+#                ^ other.source.dart
+#                 ^ support.class.dart
+#                  ^ other.source.dart
+>  void covariance(covariant List<T> items) {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^^^^^^^^ entity.name.function.dart
+#                  ^^^^^^^^^ keyword.declaration.dart
+#                            ^^^^ support.class.dart
+#                                ^ other.source.dart
+#                                 ^ support.class.dart
+#                                  ^ other.source.dart
+>}

--- a/test/goldens/operators.dart.golden
+++ b/test/goldens/operators.dart.golden
@@ -1,0 +1,207 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>void foo() {
+#^^^^ storage.type.primitive.dart
+#     ^^^ entity.name.function.dart
+>  Object? a;
+#  ^^^^^^ support.class.dart
+#        ^ keyword.operator.ternary.dart
+#           ^ punctuation.terminator.dart
+>  if (1 == 2) {}
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^^ keyword.operator.comparison.dart
+#           ^ constant.numeric.dart
+>  if (1 != 2) {}
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^^ keyword.operator.comparison.dart
+#           ^ constant.numeric.dart
+>  if (1 < 2) {}
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^ keyword.operator.comparison.dart
+#          ^ constant.numeric.dart
+>  if (1 <= 2) {}
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^^ keyword.operator.comparison.dart
+#           ^ constant.numeric.dart
+>  if (1 > 2) {}
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^ keyword.operator.comparison.dart
+#          ^ constant.numeric.dart
+>  if (1 >= 2) {}
+#  ^^ keyword.control.dart
+#      ^ constant.numeric.dart
+#        ^^ keyword.operator.comparison.dart
+#           ^ constant.numeric.dart
+>  var b = 1 < 2 ? 1 / 1 : 2 * 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^ keyword.operator.comparison.dart
+#              ^ constant.numeric.dart
+#                ^ keyword.operator.ternary.dart
+#                  ^ constant.numeric.dart
+#                    ^ keyword.operator.arithmetic.dart
+#                      ^ constant.numeric.dart
+#                        ^ keyword.operator.ternary.dart
+#                          ^ constant.numeric.dart
+#                            ^ keyword.operator.arithmetic.dart
+#                              ^ constant.numeric.dart
+#                               ^ punctuation.terminator.dart
+>  a ??= b;
+#    ^^ keyword.operator.ternary.dart
+#      ^ keyword.operator.assignment.dart
+#         ^ punctuation.terminator.dart
+>  b += 1;
+#    ^^ keyword.operator.assignment.arithmetic.dart
+#       ^ constant.numeric.dart
+#        ^ punctuation.terminator.dart
+>  b -= 1;
+#    ^^ keyword.operator.assignment.arithmetic.dart
+#       ^ constant.numeric.dart
+#        ^ punctuation.terminator.dart
+>  b = b / 2;
+#    ^ keyword.operator.assignment.dart
+#        ^ keyword.operator.arithmetic.dart
+#          ^ constant.numeric.dart
+#           ^ punctuation.terminator.dart
+>  b = b ~/ 2;
+#    ^ keyword.operator.assignment.dart
+#        ^ keyword.operator.bitwise.dart
+#         ^ keyword.operator.arithmetic.dart
+#           ^ constant.numeric.dart
+#            ^ punctuation.terminator.dart
+>  b = b % 2;
+#    ^ keyword.operator.assignment.dart
+#        ^ keyword.operator.arithmetic.dart
+#          ^ constant.numeric.dart
+#           ^ punctuation.terminator.dart
+>  b++;
+#   ^^ keyword.operator.increment-decrement.dart
+#     ^ punctuation.terminator.dart
+>  b--;
+#   ^^ keyword.operator.increment-decrement.dart
+#     ^ punctuation.terminator.dart
+>  ++b;
+#  ^^ keyword.operator.increment-decrement.dart
+#     ^ punctuation.terminator.dart
+>  --b;
+#  ^^ keyword.operator.increment-decrement.dart
+#     ^ punctuation.terminator.dart
+>  var c = 1 >> 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^^ keyword.operator.bitwise.dart
+#               ^ constant.numeric.dart
+#                ^ punctuation.terminator.dart
+>  c >>= 1;
+#    ^^ keyword.operator.bitwise.dart
+#      ^ keyword.operator.assignment.dart
+#        ^ constant.numeric.dart
+#         ^ punctuation.terminator.dart
+>  var d = 1 << 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^^ keyword.operator.bitwise.dart
+#               ^ constant.numeric.dart
+#                ^ punctuation.terminator.dart
+>  d <<= 2;
+#    ^^ keyword.operator.bitwise.dart
+#      ^ keyword.operator.assignment.dart
+#        ^ constant.numeric.dart
+#         ^ punctuation.terminator.dart
+>  var e = 1 >>> 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^^^ keyword.operator.bitwise.dart
+#                ^ constant.numeric.dart
+#                 ^ punctuation.terminator.dart
+>  e >>>= 3;
+#    ^^^ keyword.operator.bitwise.dart
+#       ^ keyword.operator.assignment.dart
+#         ^ constant.numeric.dart
+#          ^ punctuation.terminator.dart
+>  var f = -b;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ keyword.operator.arithmetic.dart
+#            ^ punctuation.terminator.dart
+>  var g = 1 & 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^ keyword.operator.bitwise.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>  var h = 1 ^ 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^ keyword.operator.bitwise.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>  var i = ~2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ keyword.operator.bitwise.dart
+#           ^ constant.numeric.dart
+#            ^ punctuation.terminator.dart
+>  var j = 1 & 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^ keyword.operator.bitwise.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>  j &= 2;
+#    ^ keyword.operator.bitwise.dart
+#     ^ keyword.operator.assignment.dart
+#       ^ constant.numeric.dart
+#        ^ punctuation.terminator.dart
+>  j ^= 2;
+#    ^ keyword.operator.bitwise.dart
+#     ^ keyword.operator.assignment.dart
+#       ^ constant.numeric.dart
+#        ^ punctuation.terminator.dart
+>  j |= 2;
+#    ^ keyword.operator.bitwise.dart
+#     ^ keyword.operator.assignment.dart
+#       ^ constant.numeric.dart
+#        ^ punctuation.terminator.dart
+>  var k = 1 ^ 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^ keyword.operator.bitwise.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>  var l = 1 | 2;
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ constant.numeric.dart
+#            ^ keyword.operator.bitwise.dart
+#              ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>  var m = !(a == a && false || true);
+#  ^^^ storage.type.primitive.dart
+#        ^ keyword.operator.assignment.dart
+#          ^ keyword.operator.logical.dart
+#              ^^ keyword.operator.comparison.dart
+#                   ^^ keyword.operator.bitwise.dart
+#                      ^^^^^ constant.language.dart
+#                            ^^ keyword.operator.bitwise.dart
+#                               ^^^^ constant.language.dart
+#                                    ^ punctuation.terminator.dart
+>}

--- a/test/goldens/parameters.dart.golden
+++ b/test/goldens/parameters.dart.golden
@@ -1,0 +1,46 @@
+>void f1() {}
+#^^^^ storage.type.primitive.dart
+#     ^^ entity.name.function.dart
+>void f2(String a) {}
+#^^^^ storage.type.primitive.dart
+#     ^^ entity.name.function.dart
+#        ^^^^^^ support.class.dart
+>void f3(String a, [int? b]) {}
+#^^^^ storage.type.primitive.dart
+#     ^^ entity.name.function.dart
+#        ^^^^^^ support.class.dart
+#                ^ punctuation.comma.dart
+#                   ^^^ support.class.dart
+#                      ^ keyword.operator.ternary.dart
+>void f4(String a, {int? b}) {}
+#^^^^ storage.type.primitive.dart
+#     ^^ entity.name.function.dart
+#        ^^^^^^ support.class.dart
+#                ^ punctuation.comma.dart
+#                   ^^^ support.class.dart
+#                      ^ keyword.operator.ternary.dart
+>void f5(String a, {required int b}) {}
+#^^^^ storage.type.primitive.dart
+#     ^^ entity.name.function.dart
+#        ^^^^^^ support.class.dart
+#                ^ punctuation.comma.dart
+#                   ^^^^^^^^ storage.modifier.dart
+#                            ^^^ support.class.dart
+>void f6(
+#^^^^ storage.type.primitive.dart
+#     ^^ entity.name.function.dart
+>  String a,
+#  ^^^^^^ support.class.dart
+#          ^ punctuation.comma.dart
+>  List<Map<String, String>> Function(String a) b,
+#  ^^^^ support.class.dart
+#      ^ other.source.dart
+#       ^^^ support.class.dart
+#          ^ other.source.dart
+#           ^^^^^^ support.class.dart
+#                   ^^^^^^ support.class.dart
+#                         ^ other.source.dart
+#                            ^^^^^^^^ support.class.dart
+#                                     ^^^^^^ support.class.dart
+#                                                ^ punctuation.comma.dart
+>) {}

--- a/test/goldens/string_interpolation.dart.golden
+++ b/test/goldens/string_interpolation.dart.golden
@@ -1,0 +1,97 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>void values() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^ entity.name.function.dart
+>  final i = 1;
+#  ^^^^^ storage.modifier.dart
+#          ^ keyword.operator.assignment.dart
+#            ^ constant.numeric.dart
+#             ^ punctuation.terminator.dart
+>  final j = 2;
+#  ^^^^^ storage.modifier.dart
+#          ^ keyword.operator.assignment.dart
+#            ^ constant.numeric.dart
+#             ^ punctuation.terminator.dart
+>
+>  print('the value of \$i is $i');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^ string.interpolated.single.dart
+#                      ^^ string.interpolated.single.dart constant.character.escape.dart
+#                        ^^^^^^ string.interpolated.single.dart
+#                              ^ string.interpolated.single.dart variable.parameter.dart
+#                               ^ string.interpolated.single.dart
+#                                 ^ punctuation.terminator.dart
+>  print('the value after \$i is ${i + 1}');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
+#                         ^^ string.interpolated.single.dart constant.character.escape.dart
+#                           ^^^^^ string.interpolated.single.dart
+#                                ^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                  ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                                   ^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                      ^ string.interpolated.single.dart string.interpolated.expression.dart constant.numeric.dart
+#                                       ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                        ^ string.interpolated.single.dart
+#                                          ^ punctuation.terminator.dart
+>  print('the value of \$i + \$j is ${i + j}');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^ string.interpolated.single.dart
+#                      ^^ string.interpolated.single.dart constant.character.escape.dart
+#                        ^^^^ string.interpolated.single.dart
+#                            ^^ string.interpolated.single.dart constant.character.escape.dart
+#                              ^^^^^ string.interpolated.single.dart
+#                                   ^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                     ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                                      ^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                         ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                                          ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                           ^ string.interpolated.single.dart
+#                                             ^ punctuation.terminator.dart
+>}
+>
+>void functions() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^^^ entity.name.function.dart
+>  print('${() {
+#  ^^^^^ entity.name.function.dart
+#        ^ string.interpolated.single.dart
+#         ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+>    return 'Hello';
+#^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#    ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#          ^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+>  }}');
+#^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#   ^^ string.interpolated.single.dart
+#      ^ punctuation.terminator.dart
+>  print('print(${() {
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^ string.interpolated.single.dart
+#               ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+>    return 'Hello';
+#^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#    ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#          ^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+>  }()})');
+#^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#   ^^^^^ string.interpolated.single.dart
+#         ^ punctuation.terminator.dart
+>  print('${() => 'Hello'}');
+#  ^^^^^ entity.name.function.dart
+#        ^ string.interpolated.single.dart
+#         ^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                         ^ string.interpolated.single.dart
+#                           ^ punctuation.terminator.dart
+>  print('print(${(() => 'Hello')()})');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^ string.interpolated.single.dart
+#               ^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                   ^^ string.interpolated.single.dart
+#                                      ^ punctuation.terminator.dart
+>}

--- a/test/support/span_parser.dart
+++ b/test/support/span_parser.dart
@@ -1,0 +1,785 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// This file is taken from DevTools and should be kept in-sync with any changes
+// that affect the resulting tokens.
+//
+// https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
+
+import 'dart:collection';
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:string_scanner/string_scanner.dart';
+
+// ignore: avoid_classes_with_only_static_members
+abstract class SpanParser {
+  /// Takes a TextMate [Grammar] and a [String] and outputs a list of
+  /// [ScopeSpan]s corresponding to the parsed input.
+  static List<ScopeSpan> parse(Grammar grammar, String src) {
+    final scopeStack = ScopeStack();
+    final scanner = LineScanner(src);
+    while (!scanner.isDone) {
+      final foundMatch =
+          grammar.topLevelMatcher.scan(grammar, scanner, scopeStack);
+      if (!foundMatch && !scanner.isDone) {
+        // Found no match, move forward by a character and try again.
+        scanner.readChar();
+      }
+    }
+    scopeStack.popAll(scanner.location);
+    return scopeStack.spans;
+  }
+}
+
+/// A representation of a TextMate grammar used to create [ScopeSpan]s
+/// representing scopes within a body of text.
+///
+/// References used:
+///   - Grammar specification:
+///       https://macromates.com/manual/en/language_grammars#language_grammars
+///   - Helpful blog post which clears up ambiguities in the spec:
+///       https://www.apeth.com/nonblog/stories/textmatebundle.html
+///
+class Grammar {
+  factory Grammar.fromJson(Map<String, Object?> json) {
+    return Grammar._(
+      name: json['name'] as String,
+      scopeName: json['scopeName'] as String,
+      topLevelMatcher: _Matcher.parse(json),
+      repository: Repository.build(json),
+    );
+  }
+
+  Grammar._({
+    this.name,
+    this.scopeName,
+    required this.topLevelMatcher,
+    required this.repository,
+  });
+
+  final String? name;
+
+  final String? scopeName;
+
+  final _Matcher topLevelMatcher;
+
+  final Repository repository;
+
+  @override
+  String toString() {
+    return const JsonEncoder.withIndent('  ').convert({
+      'name': name,
+      'scopeName': scopeName,
+      'topLevelMatcher': topLevelMatcher.toJson(),
+      'repository': repository.toJson(),
+    });
+  }
+}
+
+/// A representation of a span of text which has `scope` applied to it.
+class ScopeSpan {
+  ScopeSpan({
+    required this.scopes,
+    required ScopeStackLocation startLocation,
+    required ScopeStackLocation endLocation,
+  })  : _startLocation = startLocation,
+        _endLocation = endLocation;
+
+  ScopeStackLocation get startLocation => _startLocation;
+  ScopeStackLocation get endLocation => _endLocation;
+  int get start => _startLocation.position;
+  int get end => _endLocation.position;
+  int get length => end - start;
+
+  final ScopeStackLocation _startLocation;
+  ScopeStackLocation _endLocation;
+
+  /// The one-based line number.
+  int get line => startLocation.line + 1;
+
+  /// The one-based column number.
+  int get column => startLocation.column + 1;
+
+  final List<String> scopes;
+
+  bool contains(int token) => (start <= token) && (token < end);
+
+  /// Splits the current [ScopeSpan] into multiple spans separated by [cond].
+  /// This is useful for post-processing the results from a rule with a while
+  /// condition as formatting should not be applied to the characters that
+  /// match the while condition.
+  List<ScopeSpan> split(LineScanner scanner, RegExp cond) {
+    final splitSpans = <ScopeSpan>[];
+
+    // Create a temporary scanner, copying [0, end] to ensure that line/column
+    // information is consistent with the original scanner.
+    final splitScanner = LineScanner(
+      scanner.substring(0, end),
+      position: start,
+    );
+
+    // Start with a copy of the original span
+    ScopeSpan current = ScopeSpan(
+      scopes: scopes.toList(),
+      startLocation: startLocation,
+      endLocation: endLocation,
+    );
+
+    while (!splitScanner.isDone) {
+      if (splitScanner.matches(cond)) {
+        // Update the end position for this span as it's been fully processed.
+        current._endLocation = splitScanner.location;
+        splitSpans.add(current);
+
+        // Move the scanner position past the matched condition.
+        splitScanner.scan(cond);
+
+        // Create a new span based on the current position.
+        current = ScopeSpan(
+          scopes: scopes.toList(),
+          startLocation: splitScanner.location,
+          // Will be updated later.
+          endLocation: ScopeStackLocation.zero,
+        );
+      } else {
+        // Move scanner position forward.
+        splitScanner.readChar();
+      }
+    }
+    // Finish processing the last span, which will always have the same end
+    // position as the span we're splitting.
+    current._endLocation = endLocation;
+    splitSpans.add(current);
+
+    return splitSpans;
+  }
+
+  @override
+  String toString() {
+    return '[$start, $end, $line:$column (len: $length)] = $scopes';
+  }
+}
+
+/// A top-level repository of rules that can be referenced within other rules
+/// using the 'includes' keyword.
+class Repository {
+  Repository.build(Map<String, Object?> grammarJson) {
+    final repositoryJson = (grammarJson['repository'] as Map<String, Object?>?)
+        ?.cast<String, Map<String, Object?>>();
+    if (repositoryJson == null) {
+      return;
+    }
+    for (final subRepo in repositoryJson.keys) {
+      matchers[subRepo] = _Matcher.parse(repositoryJson[subRepo]!);
+    }
+  }
+
+  final matchers = <String?, _Matcher>{};
+
+  Map<String, Object?> toJson() {
+    return {
+      for (final entry in matchers.entries)
+        if (entry.key != null) entry.key!: entry.value.toJson(),
+    };
+  }
+}
+
+abstract class _Matcher {
+  factory _Matcher.parse(Map<String, Object?> json) {
+    if (_IncludeMatcher.isType(json)) {
+      return _IncludeMatcher(json['include'] as String);
+    } else if (_SimpleMatcher.isType(json)) {
+      return _SimpleMatcher(json);
+    } else if (_MultilineMatcher.isType(json)) {
+      return _MultilineMatcher(json);
+    } else if (_PatternMatcher.isType(json)) {
+      return _PatternMatcher(json);
+    }
+    throw StateError('Unknown matcher type: $json');
+  }
+
+  _Matcher._(Map<String, Object?> json) : name = json['name'] as String?;
+
+  final String? name;
+
+  bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack);
+
+  void _applyCapture(
+    Grammar grammar,
+    LineScanner scanner,
+    ScopeStack scopeStack,
+    Map<String, Object?>? captures,
+    ScopeStackLocation location,
+  ) {
+    final lastMatch = scanner.lastMatch!;
+    final start = lastMatch.start;
+    final end = lastMatch.end;
+    final matchStartLocation = location;
+    if (captures != null) {
+      final match = scanner.substring(start, end);
+      for (int i = 0; i <= lastMatch.groupCount; ++i) {
+        // Skip if we don't have a scope or nested patterns for this capture.
+        if (!captures.containsKey(i.toString())) continue;
+
+        final captureText = lastMatch.group(i);
+        if (captureText == null || captureText.isEmpty) continue;
+
+        final startOffset = match.indexOf(captureText);
+        final capture = captures[i.toString()] as Map<String, Object?>;
+        final captureStartLocation = matchStartLocation.offset(startOffset);
+        final captureEndLocation =
+            captureStartLocation.offset(captureText.length);
+        final captureName = capture['name'] as String?;
+
+        scopeStack.push(captureName, captureStartLocation);
+
+        // Handle nested pattern matchers.
+        if (capture.containsKey('patterns')) {
+          final captureScanner = LineScanner(
+            scanner.substring(0, captureEndLocation.position),
+            position: captureStartLocation.position,
+          );
+          _Matcher.parse(capture).scan(grammar, captureScanner, scopeStack);
+        }
+
+        scopeStack.pop(captureName, captureEndLocation);
+      }
+    }
+  }
+
+  Map<String, Object?> toJson();
+}
+
+/// A simple matcher which matches a single line.
+class _SimpleMatcher extends _Matcher {
+  _SimpleMatcher(Map<String, Object?> json)
+      : match = RegExp(json['match'] as String, multiLine: true),
+        captures = (json['captures'] as Map<String, Object?>?)
+            ?.cast<String, Map<String, Object?>>(),
+        super._(json);
+
+  static bool isType(Map<String, Object?> json) {
+    return json.containsKey('match');
+  }
+
+  final RegExp match;
+
+  final Map<String, Object?>? captures;
+
+  @override
+  bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
+    final location = scanner.location;
+    if (scanner.scan(match)) {
+      scopeStack.push(name, location);
+      _applyCapture(grammar, scanner, scopeStack, captures, location);
+      scopeStack.pop(name, scanner.location);
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      if (name != null) 'name': name,
+      'match': match.pattern,
+      if (captures != null) 'captures': captures,
+    };
+  }
+}
+
+class _MultilineMatcher extends _Matcher {
+  _MultilineMatcher(Map<String, Object?> json)
+      : begin = RegExp(json['begin'] as String, multiLine: true),
+        beginCaptures = json['beginCaptures'] as Map<String, Object?>?,
+        contentName = json['contentName'] as String?,
+        end = json['end'] == null
+            ? null
+            : RegExp(json['end'] as String, multiLine: true),
+        endCaptures = json['endCaptures'] as Map<String, Object?>?,
+        captures = json['captures'] as Map<String, Object?>?,
+        whileCond = json['while'] == null
+            ? null
+            : RegExp(json['while'] as String, multiLine: true),
+        patterns = (json['patterns'] as List<Object?>?)
+            ?.cast<Map<String, Object?>>()
+            .map((e) => _Matcher.parse(e))
+            .toList()
+            .cast<_Matcher>(),
+        super._(json);
+
+  static bool isType(Map<String, Object?> json) {
+    return json.containsKey('begin') &&
+        (json.containsKey('end') || json.containsKey('while'));
+  }
+
+  /// A regular expression which defines the beginning match of this rule. This
+  /// property is required and must be defined along with either `end` or
+  /// `while`.
+  final RegExp begin;
+
+  /// A set of scopes to apply to groups captured by `begin`. `captures` should
+  /// be null if this property is provided.
+  final Map<String, Object?>? beginCaptures;
+
+  /// The scope that applies to the content between the matches found by
+  /// `begin` and `end`.
+  final String? contentName;
+
+  /// A regular expression which defines the match signaling the end of the
+  /// rule application. This property is mutually exclusive with the `while`
+  /// property.
+  final RegExp? end;
+
+  /// A set of scopes to apply to groups captured by `begin`. `captures` should
+  /// be null if this property is provided.
+  final Map<String, Object?>? endCaptures;
+
+  /// A regular expression corresponding with the `while` property used to
+  /// determine if the next line should have the current rule applied. If
+  /// `patterns` is provided, the contents of a line that satisfy this regular
+  /// expression will be processed against the provided patterns.
+  ///
+  /// This expression is applied to every line **after** the first line matched
+  /// by `begin`. If this expression fails after the line matched by `begin`,
+  /// the overall rule does not fail and the resulting [ScopeSpan]s will consist
+  /// of matches found in the first line.
+  ///
+  /// This property is mutually exclusive with the `end` property.
+  final RegExp? whileCond;
+
+  /// A set of scopes to apply to groups captured by `begin` and `end`.
+  /// Providing this property is the equivalent of setting `beginCaptures` and
+  /// `endCaptures` to the same value. `beginCaptures` and `endCaptures` should
+  /// be null if this property is provided.
+  final Map<String, Object?>? captures;
+
+  final List<_Matcher>? patterns;
+
+  void _scanBegin(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
+    final location = scanner.location;
+    if (!scanner.scan(begin)) {
+      // This shouldn't happen since we've already checked that `begin` matches
+      // the beginning of the string.
+      throw StateError('Expected ${begin.pattern} to match.');
+    }
+    _processCaptureHelper(
+      grammar,
+      scanner,
+      scopeStack,
+      beginCaptures,
+      location,
+    );
+  }
+
+  void _scanToEndOfLine(
+    Grammar grammar,
+    LineScanner scanner,
+    ScopeStack scopeStack,
+  ) {
+    while (!scanner.isDone) {
+      if (String.fromCharCode(scanner.peekChar()!) == '\n') {
+        scanner.readChar();
+        break;
+      }
+      bool foundMatch = false;
+      for (final pattern in patterns ?? <_Matcher>[]) {
+        if (pattern.scan(grammar, scanner, scopeStack)) {
+          foundMatch = true;
+          break;
+        }
+      }
+      if (!foundMatch) {
+        scanner.readChar();
+      }
+    }
+  }
+
+  void _scanUpToEndMatch(
+    Grammar grammar,
+    LineScanner scanner,
+    ScopeStack scopeStack,
+  ) {
+    while (!scanner.isDone && end != null && !scanner.matches(end!)) {
+      bool foundMatch = false;
+      for (final pattern in patterns ?? <_Matcher>[]) {
+        if (pattern.scan(grammar, scanner, scopeStack)) {
+          foundMatch = true;
+          break;
+        }
+      }
+      if (!foundMatch) {
+        // Move forward by a character, try again.
+        scanner.readChar();
+      }
+    }
+  }
+
+  void _scanEnd(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
+    final location = scanner.location;
+    if (end != null && !scanner.scan(end!)) {
+      return null;
+    }
+    _processCaptureHelper(grammar, scanner, scopeStack, endCaptures, location);
+  }
+
+  void _processCaptureHelper(
+    Grammar grammar,
+    LineScanner scanner,
+    ScopeStack scopeStack,
+    Map<String, Object?>? customCaptures,
+    ScopeStackLocation location,
+  ) {
+    if (contentName == null || (customCaptures ?? captures) != null) {
+      _applyCapture(
+        grammar,
+        scanner,
+        scopeStack,
+        customCaptures ?? captures,
+        location,
+      );
+    }
+  }
+
+  @override
+  bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
+    if (!scanner.matches(begin)) {
+      return false;
+    }
+
+    scopeStack.push(name, scanner.location);
+    _scanBegin(grammar, scanner, scopeStack);
+    if (end != null) {
+      scopeStack.push(contentName, scanner.location);
+      _scanUpToEndMatch(grammar, scanner, scopeStack);
+      scopeStack.pop(contentName, scanner.location);
+      _scanEnd(grammar, scanner, scopeStack);
+    } else if (whileCond != null) {
+      // Find the range of the string that is matched by the while condition.
+      final start = scanner.position;
+      _skipLine(scanner);
+      while (!scanner.isDone && whileCond != null && scanner.scan(whileCond!)) {
+        _skipLine(scanner);
+      }
+      final end = scanner.position;
+
+      // Create a temporary scanner to ensure that rules that don't find an
+      // end match don't try and match all the way to the end of the file.
+      final contentScanner = LineScanner(
+        scanner.substring(0, end),
+        position: start,
+      );
+
+      // Capture a marker for where the contents start, used later to split
+      // spans.
+      final whileContentBeginMarker = scopeStack.marker();
+
+      _scanToEndOfLine(grammar, contentScanner, scopeStack);
+
+      // Process each line until the `while` condition fails.
+      while (!contentScanner.isDone &&
+          whileCond != null &&
+          contentScanner.scan(whileCond!)) {
+        _scanToEndOfLine(grammar, contentScanner, scopeStack);
+      }
+
+      // Now, split any spans produced whileContentBeginMarker by `whileCond`.
+      scopeStack.splitFromMarker(
+        scanner,
+        whileContentBeginMarker,
+        whileCond!,
+      );
+    } else {
+      throw StateError(
+        "One of 'end' or 'while' must be provided for rule: $name",
+      );
+    }
+    scopeStack.pop(name, scanner.location);
+    return true;
+  }
+
+  void _skipLine(LineScanner scanner) {
+    scanner.scan(RegExp('.*\n'));
+  }
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      if (name != null) 'name': name,
+      'begin': begin.pattern,
+      if (beginCaptures != null) 'beginCaptures': beginCaptures,
+      if (end != null) 'end': end!.pattern,
+      if (endCaptures != null) 'endCaptures': endCaptures,
+      if (whileCond != null) 'while': whileCond!.pattern,
+      if (patterns != null)
+        'patterns': patterns!.map((e) => e.toJson()).toList(),
+    };
+  }
+}
+
+class _PatternMatcher extends _Matcher {
+  _PatternMatcher(Map<String, Object?> json)
+      : patterns = (json['patterns'] as List<Object?>?)
+            ?.cast<Map<String, Object?>>()
+            .map((e) => _Matcher.parse(e))
+            .toList()
+            .cast<_Matcher>(),
+        super._(json);
+
+  static bool isType(Map<String, Object?> json) {
+    return json.containsKey('patterns');
+  }
+
+  final List<_Matcher>? patterns;
+
+  @override
+  bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
+    // Try each rule in the include and return after the first successful match.
+    for (final pattern in patterns!) {
+      if (pattern.scan(grammar, scanner, scopeStack)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      if (name != null) 'name': name,
+      if (patterns != null)
+        'patterns': patterns!.map((e) => e.toJson()).toList(),
+    };
+  }
+}
+
+/// A [_Matcher] that corresponds to an `include` rule referenced in a
+/// `patterns` array. Allows for executing rules defined within a
+/// [Repository].
+class _IncludeMatcher extends _Matcher {
+  _IncludeMatcher(String include)
+      : include = include.substring(1),
+        super._({});
+
+  final String include;
+
+  static bool isType(Map<String, Object?> json) {
+    return json.containsKey('include');
+  }
+
+  @override
+  bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
+    final matcher = grammar.repository.matchers[include];
+    if (matcher == null) {
+      throw StateError('Could not find $include in the repository.');
+    }
+    return matcher.scan(grammar, scanner, scopeStack);
+  }
+
+  @override
+  Map<String, Object?> toJson() {
+    return {
+      'include': include,
+    };
+  }
+}
+
+/// Tracks the current scope stack, producing [ScopeSpan]s as the contents
+/// change.
+class ScopeStack {
+  ScopeStack();
+
+  final stack = Queue<ScopeStackItem>();
+  final spans = <ScopeSpan>[];
+
+  /// Location where the next produced span should begin.
+  ScopeStackLocation _nextLocation = ScopeStackLocation.zero;
+
+  /// Adds a scope for a given region.
+  ///
+  /// This method is the same as calling [push] and then [pop] with the same
+  /// args.
+  void add(
+    String? scope, {
+    required ScopeStackLocation start,
+    required ScopeStackLocation end,
+  }) {
+    push(scope, start);
+    pop(scope, end);
+  }
+
+  /// Pushes a new scope onto the stack starting at [start].
+  void push(String? scope, ScopeStackLocation location) {
+    if (scope == null) return;
+
+    // If the stack is empty, seed the position which is used for the start
+    // of the next produced token.
+    if (stack.isEmpty) {
+      _nextLocation = location;
+    }
+
+    // Whenever we push a new item, produce a span for the region between the
+    // last started scope and the new current position.
+    if (location.position > _nextLocation.position) {
+      final scopes = stack.map((item) => item.scope).toSet();
+      _produceSpan(scopes, end: location);
+    }
+
+    // Add this new scope to the stack, but don't produce its token yet. We will
+    // do that when the next item is pushed (in which case we'll fill the gap),
+    // or when this item is popped (in which case we'll produce a span for that
+    // full region).
+    stack.add(ScopeStackItem(scope, location));
+  }
+
+  /// Pops the last scope off the stack, producing a token if necessary up until
+  /// [end].
+  void pop(String? scope, ScopeStackLocation end) {
+    if (scope == null) return null;
+    assert(stack.isNotEmpty);
+
+    final scopes = stack.map((item) => item.scope).toSet();
+    final last = stack.removeLast();
+    assert(last.scope == scope);
+    assert(last.location.position <= end.position);
+
+    _produceSpan(scopes, end: end);
+  }
+
+  void popAll(ScopeStackLocation location) {
+    while (stack.isNotEmpty) {
+      pop(stack.last.scope, location);
+    }
+  }
+
+  /// Captures a marker to identify spans produced before/after this call.
+  ScopeStackMarker marker() {
+    return ScopeStackMarker(spanIndex: spans.length, location: _nextLocation);
+  }
+
+  /// Splits all spans created since [begin] by [condition].
+  ///
+  /// This is used to handle multiline spans that use begin/end such as
+  /// capturing triple-backtick code blocks that would have captured the leading
+  /// '/// ', which should not be included.
+  void splitFromMarker(
+    LineScanner scanner,
+    ScopeStackMarker begin,
+    RegExp condition,
+  ) {
+    // Remove the spans to be split. We will push new spans after splitting.
+    final spansToSplit = spans.sublist(begin.spanIndex);
+    if (spansToSplit.isEmpty) return;
+    spans.removeRange(begin.spanIndex, spans.length);
+
+    // Also rewind the last positions to the start place.
+    _nextLocation = begin.location;
+
+    // Add the split spans individually.
+    for (final span in spansToSplit
+        .expand((spanToSplit) => spanToSplit.split(scanner, condition))) {
+      // To handler spans with multiple scopes, we need to push each scope, and
+      // then pop each scope. We cannot use `add`.
+      for (final scope in span.scopes) {
+        push(scope, span.startLocation);
+      }
+      for (final scope in span.scopes.reversed) {
+        pop(scope, span.endLocation);
+      }
+    }
+  }
+
+  void _produceSpan(
+    Set<String> scopes, {
+    required ScopeStackLocation end,
+  }) {
+    // Don't produce zero-width spans.
+    if (end.position == _nextLocation.position) return;
+
+    // If the new span starts at the same place that the previous one ends and
+    // has the same scopes, we can replace the previous one with a single new
+    // larger span.
+    final newScopes = scopes.toList();
+    final lastSpan = spans.lastOrNull;
+    if (lastSpan != null &&
+        lastSpan.endLocation.position == _nextLocation.position &&
+        lastSpan.scopes.equals(newScopes)) {
+      final span = ScopeSpan(
+        scopes: newScopes,
+        startLocation: lastSpan.startLocation,
+        endLocation: end,
+      );
+      // Replace the last span with this one.
+      spans[spans.length - 1] = span;
+    } else {
+      final span = ScopeSpan(
+        scopes: newScopes,
+        startLocation: _nextLocation,
+        endLocation: end,
+      );
+      spans.add(span);
+    }
+    _nextLocation = end;
+  }
+}
+
+/// An item pushed onto the scope stack, consisting of a [String] scope and a
+/// location.
+class ScopeStackItem {
+  ScopeStackItem(this.scope, this.location);
+
+  final String scope;
+  final ScopeStackLocation location;
+}
+
+/// A marker tracking a position in the list of produced tokens.
+///
+/// Used for back-tracking when handling nested multiline tokens.
+class ScopeStackMarker {
+  ScopeStackMarker({
+    required this.spanIndex,
+    required this.location,
+  });
+
+  final int spanIndex;
+  final ScopeStackLocation location;
+}
+
+/// A location (including offset, line, column) in the code parsed for scopes.
+class ScopeStackLocation {
+  const ScopeStackLocation({
+    required this.position,
+    required this.line,
+    required this.column,
+  });
+
+  static const zero = ScopeStackLocation(position: 0, line: 0, column: 0);
+
+  /// 0-based offset in content.
+  final int position;
+
+  /// 0-based line number of [position].
+  final int line;
+
+  /// 0-based column number of [position].
+  final int column;
+
+  /// Returns a location offset by [offset] characters.
+  ///
+  /// This method does not handle line wrapping so should only be used where it
+  /// is known that the offset does not wrap across a line boundary.
+  ScopeStackLocation offset(int offset) {
+    return ScopeStackLocation(
+      position: position + offset,
+      line: line,
+      column: column + offset,
+    );
+  }
+}
+
+extension LineScannerExtension on LineScanner {
+  ScopeStackLocation get location =>
+      ScopeStackLocation(position: position, line: line, column: column);
+}

--- a/test/test_files/classes.dart
+++ b/test/test_files/classes.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class Class1 {}
+
+abstract class Class2 implements Class1 {
+  String get a;
+  set a(String value);
+}
+
+class Class3 extends Class2 with MyMixin {
+  @override
+  String get a => '';
+
+  @override
+  set a(String value) {}
+
+  void method() {}
+}
+
+class Class4<T extends Class2> implements Class1 {}
+
+class MyClass {
+  void method1() {}
+  void Method2() {}
+  void get() {}
+  void set() {}
+
+  String? _foo;
+  String? get foo => _foo;
+  set foo(String? value) => _foo = value;
+}
+
+mixin MyMixin {}
+
+mixin MyMixin2 on Class1 {}
+
+extension on String {}
+
+extension StringExtension on String {}

--- a/test/test_files/classes.dart
+++ b/test/test_files/classes.dart
@@ -39,3 +39,16 @@ mixin MyMixin2 on Class1 {}
 extension on String {}
 
 extension StringExtension on String {}
+
+extension StringListExtension on List<String> {}
+
+extension<T extends String> on T {}
+
+class my_lowercase_class {
+  my_lowercase_class? foo() => null;
+  List<my_lowercase_class>? bar() => null;
+}
+
+class A1<T> {}
+
+class A2<T> extends A1<T> {}

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -1,0 +1,48 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Multiline dartdoc comment.
+///
+/// ```
+/// doc
+/// ```
+///
+/// ...
+var a;
+
+/*
+ * Old-style dartdoc
+ *
+ * ...
+ */
+var b;
+
+/* Inline block comment */
+var c;
+
+/**
+ * Nested block
+ *
+ * /**
+ *  * Nested block
+ *  */
+ */
+var d;
+
+/**
+ * Nested
+ *
+ * /* Inline */
+ */
+var e;
+
+/* Nested /* Inline */ */
+var f;
+
+// Simple comment
+var g;
+
+/// Dartdoc with reference to [a].
+/// And a link to [example.org](http://example.org/).
+var h;

--- a/test/test_files/control.dart
+++ b/test/test_files/control.dart
@@ -1,0 +1,44 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+void err() {
+  try {
+    throw '';
+  } on ArgumentError {
+    rethrow;
+  } catch (e) {
+    print('e');
+  }
+}
+
+void loops() {
+  while (1 > 2) {
+    if (3 > 4) {
+      continue;
+    } else {
+      break;
+    }
+    return;
+  }
+
+  do {
+    print('');
+  } while (1 > 2);
+}
+
+void switches() {
+  Object? i = 1;
+  switch (i as int) {
+    case 1:
+      break;
+    default:
+      return;
+  }
+}
+
+void conditions() {
+  if (1 > 2) {
+  } else if (3 > 4) {
+  } else {}
+}

--- a/test/test_files/directives.dart
+++ b/test/test_files/directives.dart
@@ -1,0 +1,13 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+import 'dart:io' as io;
+import 'dart:io' show File;
+import 'dart:io' hide Directory;
+import 'dart:io' show File hide Directory;
+import 'dart:io' as io show Directory;
+import 'dart:async' deferred as deferredAsync show Future;
+
+export 'comments.dart';

--- a/test/test_files/functions.dart
+++ b/test/test_files/functions.dart
@@ -40,3 +40,5 @@ Stream<String> asyncYieldStar() async* {
   await Future.delayed(const Duration(seconds: 1));
   yield* asyncYield();
 }
+
+T foo<T extends String>(String a) => throw UnimplementedError();

--- a/test/test_files/functions.dart
+++ b/test/test_files/functions.dart
@@ -1,0 +1,42 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+void simplePrint() {
+  print('hello world');
+}
+
+noReturnValue() {
+  print('hello world');
+}
+
+void returns() {
+  return;
+}
+
+Future<void> asyncPrint() async {
+  await Future.delayed(const Duration(seconds: 1));
+  print('hello world');
+}
+
+Map<T1, List<T2>> nestedGenerics<T1, T2 extends String>() {
+  return {};
+}
+
+Iterable<String> syncYield() sync* {
+  yield '';
+}
+
+Iterable<String> syncYieldStar() sync* {
+  yield* syncYield();
+}
+
+Stream<String> asyncYield() async* {
+  await Future.delayed(const Duration(seconds: 1));
+  yield '';
+}
+
+Stream<String> asyncYieldStar() async* {
+  await Future.delayed(const Duration(seconds: 1));
+  yield* asyncYield();
+}

--- a/test/test_files/literals.dart
+++ b/test/test_files/literals.dart
@@ -1,0 +1,19 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+const a = 'aaaaa';
+
+const list1 = [];
+const list2 = <String>[];
+const list3 = ['', '$a'];
+const list4 = <String>['', '$a'];
+
+const set1 = {};
+const set2 = <String>{};
+const set3 = {'', '$a'};
+const set4 = <String>{'', '$a'};
+
+const map1 = <String, String>{};
+const map2 = {'': '$a'};
+const map3 = <String, String>{'': '$a'};

--- a/test/test_files/misc.dart
+++ b/test/test_files/misc.dart
@@ -1,0 +1,27 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+library foo;
+
+external int get externalInt;
+
+typedef StringAlias = String;
+typedef void FunctionAlias1(String a, String b);
+typedef FunctionAlias2 = void Function(String a, String b);
+
+void misc(int a, {required int b}) {
+  assert(true);
+  assert(1 == 1, 'fail');
+
+  var a = new String.fromCharCode(1);
+  const b = int.fromEnvironment('');
+  final c = '';
+  late final d = '';
+  print(d is String);
+  print(d is! String);
+}
+
+class Covariance<T> {
+  void covariance(covariant List<T> items) {}
+}

--- a/test/test_files/operators.dart
+++ b/test/test_files/operators.dart
@@ -1,0 +1,41 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+void foo() {
+  Object? a;
+  if (1 == 2) {}
+  if (1 != 2) {}
+  if (1 < 2) {}
+  if (1 <= 2) {}
+  if (1 > 2) {}
+  if (1 >= 2) {}
+  var b = 1 < 2 ? 1 / 1 : 2 * 2;
+  a ??= b;
+  b += 1;
+  b -= 1;
+  b = b / 2;
+  b = b ~/ 2;
+  b = b % 2;
+  b++;
+  b--;
+  ++b;
+  --b;
+  var c = 1 >> 2;
+  c >>= 1;
+  var d = 1 << 2;
+  d <<= 2;
+  var e = 1 >>> 2;
+  e >>>= 3;
+  var f = -b;
+  var g = 1 & 2;
+  var h = 1 ^ 2;
+  var i = ~2;
+  var j = 1 & 2;
+  j &= 2;
+  j ^= 2;
+  j |= 2;
+  var k = 1 ^ 2;
+  var l = 1 | 2;
+  var m = !(a == a && false || true);
+}

--- a/test/test_files/parameters.dart
+++ b/test/test_files/parameters.dart
@@ -1,0 +1,9 @@
+void f1() {}
+void f2(String a) {}
+void f3(String a, [int? b]) {}
+void f4(String a, {int? b}) {}
+void f5(String a, {required int b}) {}
+void f6(
+  String a,
+  List<Map<String, String>> Function(String a) b,
+) {}

--- a/test/test_files/string_interpolation.dart
+++ b/test/test_files/string_interpolation.dart
@@ -1,0 +1,23 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+void values() {
+  final i = 1;
+  final j = 2;
+
+  print('the value of \$i is $i');
+  print('the value after \$i is ${i + 1}');
+  print('the value of \$i + \$j is ${i + j}');
+}
+
+void functions() {
+  print('${() {
+    return 'Hello';
+  }}');
+  print('print(${() {
+    return 'Hello';
+  }()})');
+  print('${() => 'Hello'}');
+  print('print(${(() => 'Hello')()})');
+}


### PR DESCRIPTION
@bkonyi @devoncarew it's been bugging me that we had no good way to syntax changes besides reviewing the results manually. Dart-Code has [an open PR](https://github.com/Dart-Code/Dart-Code/pull/4067) (that will need to be redirect here when ready) that refactors quite a lot of this code that re-reminded me about this.

I found https://github.com/PanAeon/vscode-tmgrammar-test and added some basic tests to the Dart-Code repo, but really there should be tests here too. @bkonyi pointed out DevTools has some grammar parsing so rather than setting up TypeScript/npm here, it seems like we might be able to replicate that without much effort.

This PR is not complete (it has span_parser lifted from DevTools with some slight tweaks, and I think it's failing to parse some of my test code) but I wanted to get some feedback on the idea before going too far.

- `test/golden_test.dart` is the test code
- `test/support/span_parser.dart` is the grammar parser lifted from DevTools (which we may want to aim to share)
- `test/test_files/*.dart` are files we use for testing
- `test/test_file/*.dart.golden` are text files showing the scopes for each token

The output format currently matches https://github.com/PanAeon/vscode-tmgrammar-test which gives us something to compare against to ensure everything is parsing correctly (which it's not yet, but I haven't dug into because I didn't want to go too far without some feedback).

WDYT?