### PR TITLE
Split class-identifier rule up

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"fileTypes": [
 		"dart"
 	],
@@ -234,7 +234,15 @@
 		"class-identifier": {
 			"patterns": [
 				{
-					"match": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?|bool\\b|num\\b|int\\b|double\\b|dynamic\\b|(void)\\b)",
+					"name": "storage.type.primitive.dart",
+					"match": "\\bvoid\\b"
+				},
+				{
+					"name": "support.class.dart",
+					"match": "\\b(bool|num|int|double|dynamic)\\b"
+				},
+				{
+					"match": "\\b([_$]*[A-Z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?",
 					"captures": {
 						"1": {
 							"name": "support.class.dart"
@@ -245,9 +253,6 @@
 									"include": "#type-args"
 								}
 							]
-						},
-						"3": {
-							"name": "storage.type.primitive.dart"
 						}
 					}
 				}


### PR DESCRIPTION
This rule was more complicated than it needed to be to support classes/void/built-in types and was accidentally nesting capture groups (which complicates applying the grammar to source using a simple stack), so this change just splits it up.

Visually, everything looks identical in VS Code, and testing using some tests in https://github.com/dart-lang/dart-syntax-highlight/pull/28 and an npm tool (since the Dart parser doesn't handle the current grammar yet), the output is the same except for no longer wrapping the class span around the entire type args (something I don't think was intended).

(I am working on completing https://github.com/dart-lang/dart-syntax-highlight/pull/28, but I need to get the Dart parser to be able to parse the current version of the grammar file, which it currently does not).