### PR TITLE
Add test cases for records

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,3 @@
 analyzer:
   exclude:
-    - test/test_files
+    - test/test_files/**

--- a/test/goldens/records.dart.golden
+++ b/test/goldens/records.dart.golden
@@ -5,7 +5,19 @@
 >// found in the LICENSE file.
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
 >
->(int aaa, int, {String? ccc})? ddd;
+>(int, int)? aaa;
+# ^^^ support.class.dart
+#    ^ punctuation.comma.dart
+#      ^^^ support.class.dart
+#          ^ keyword.operator.ternary.dart
+#               ^ punctuation.terminator.dart
+>(int aaa, int bbb)? bbb;
+# ^^^ support.class.dart
+#        ^ punctuation.comma.dart
+#          ^^^ support.class.dart
+#                  ^ keyword.operator.ternary.dart
+#                       ^ punctuation.terminator.dart
+>(int aaa, int, {String? ccc})? ccc;
 # ^^^ support.class.dart
 #        ^ punctuation.comma.dart
 #          ^^^ support.class.dart
@@ -14,16 +26,26 @@
 #                      ^ keyword.operator.ternary.dart
 #                             ^ keyword.operator.ternary.dart
 #                                  ^ punctuation.terminator.dart
+>(int, (int, (int, String)))? ddd;
+# ^^^ support.class.dart
+#    ^ punctuation.comma.dart
+#       ^^^ support.class.dart
+#          ^ punctuation.comma.dart
+#             ^^^ support.class.dart
+#                ^ punctuation.comma.dart
+#                  ^^^^^^ support.class.dart
+#                           ^ keyword.operator.ternary.dart
+#                                ^ punctuation.terminator.dart
 >
->(int aaa, int bbb) foo((String aaaa, String? bbbb) ccc) {
+>(int aaa, int bbb) func((String aaaa, String? bbbb) ccc) {
 # ^^^ support.class.dart
 #        ^ punctuation.comma.dart
 #          ^^^ support.class.dart
-#                   ^^^ entity.name.function.dart
-#                        ^^^^^^ support.class.dart
-#                                   ^ punctuation.comma.dart
-#                                     ^^^^^^ support.class.dart
-#                                           ^ keyword.operator.ternary.dart
+#                   ^^^^ entity.name.function.dart
+#                         ^^^^^^ support.class.dart
+#                                    ^ punctuation.comma.dart
+#                                      ^^^^^^ support.class.dart
+#                                            ^ keyword.operator.ternary.dart
 >  final ddd = (1, 2, eee: '');
 #  ^^^^^ storage.modifier.dart
 #            ^ keyword.operator.assignment.dart
@@ -45,7 +67,7 @@
 >class R {
 #^^^^^ keyword.declaration.dart
 #      ^ support.class.dart
->  (int aaa, int, {String? ccc})? get ddd => null;
+>  (int aaa, int, {String? ccc})? get getter => null;
 #   ^^^ support.class.dart
 #          ^ punctuation.comma.dart
 #            ^^^ support.class.dart
@@ -54,17 +76,17 @@
 #                        ^ keyword.operator.ternary.dart
 #                               ^ keyword.operator.ternary.dart
 #                                 ^^^ keyword.declaration.dart
-#                                     ^^^ entity.name.function.dart
-#                                            ^^^^ constant.language.dart
-#                                                ^ punctuation.terminator.dart
->  final eee = (1, 2, eee: '');
+#                                     ^^^^^^ entity.name.function.dart
+#                                               ^^^^ constant.language.dart
+#                                                   ^ punctuation.terminator.dart
+>  final variable = (1, 2, eee: '');
 #  ^^^^^ storage.modifier.dart
-#            ^ keyword.operator.assignment.dart
-#               ^ constant.numeric.dart
-#                ^ punctuation.comma.dart
-#                  ^ constant.numeric.dart
-#                   ^ punctuation.comma.dart
-#                        ^ keyword.operator.ternary.dart
-#                          ^^ string.interpolated.single.dart
-#                             ^ punctuation.terminator.dart
+#                 ^ keyword.operator.assignment.dart
+#                    ^ constant.numeric.dart
+#                     ^ punctuation.comma.dart
+#                       ^ constant.numeric.dart
+#                        ^ punctuation.comma.dart
+#                             ^ keyword.operator.ternary.dart
+#                               ^^ string.interpolated.single.dart
+#                                  ^ punctuation.terminator.dart
 >}

--- a/test/goldens/records.dart.golden
+++ b/test/goldens/records.dart.golden
@@ -1,0 +1,70 @@
+>// Copyright 2022 The Chromium Authors. All rights reserved.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// Use of this source code is governed by a BSD-style license that can be
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>(int aaa, int, {String? ccc})? ddd;
+# ^^^ support.class.dart
+#        ^ punctuation.comma.dart
+#          ^^^ support.class.dart
+#             ^ punctuation.comma.dart
+#                ^^^^^^ support.class.dart
+#                      ^ keyword.operator.ternary.dart
+#                             ^ keyword.operator.ternary.dart
+#                                  ^ punctuation.terminator.dart
+>
+>(int aaa, int bbb) foo((String aaaa, String? bbbb) ccc) {
+# ^^^ support.class.dart
+#        ^ punctuation.comma.dart
+#          ^^^ support.class.dart
+#                   ^^^ entity.name.function.dart
+#                        ^^^^^^ support.class.dart
+#                                   ^ punctuation.comma.dart
+#                                     ^^^^^^ support.class.dart
+#                                           ^ keyword.operator.ternary.dart
+>  final ddd = (1, 2, eee: '');
+#  ^^^^^ storage.modifier.dart
+#            ^ keyword.operator.assignment.dart
+#               ^ constant.numeric.dart
+#                ^ punctuation.comma.dart
+#                  ^ constant.numeric.dart
+#                   ^ punctuation.comma.dart
+#                        ^ keyword.operator.ternary.dart
+#                          ^^ string.interpolated.single.dart
+#                             ^ punctuation.terminator.dart
+>  return (1, 2);
+#  ^^^^^^ keyword.control.dart
+#          ^ constant.numeric.dart
+#           ^ punctuation.comma.dart
+#             ^ constant.numeric.dart
+#               ^ punctuation.terminator.dart
+>}
+>
+>class R {
+#^^^^^ keyword.declaration.dart
+#      ^ support.class.dart
+>  (int aaa, int, {String? ccc})? get ddd => null;
+#   ^^^ support.class.dart
+#          ^ punctuation.comma.dart
+#            ^^^ support.class.dart
+#               ^ punctuation.comma.dart
+#                  ^^^^^^ support.class.dart
+#                        ^ keyword.operator.ternary.dart
+#                               ^ keyword.operator.ternary.dart
+#                                 ^^^ keyword.declaration.dart
+#                                     ^^^ entity.name.function.dart
+#                                            ^^^^ constant.language.dart
+#                                                ^ punctuation.terminator.dart
+>  final eee = (1, 2, eee: '');
+#  ^^^^^ storage.modifier.dart
+#            ^ keyword.operator.assignment.dart
+#               ^ constant.numeric.dart
+#                ^ punctuation.comma.dart
+#                  ^ constant.numeric.dart
+#                   ^ punctuation.comma.dart
+#                        ^ keyword.operator.ternary.dart
+#                          ^^ string.interpolated.single.dart
+#                             ^ punctuation.terminator.dart
+>}

--- a/test/test_files/records.dart
+++ b/test/test_files/records.dart
@@ -2,14 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-(int aaa, int, {String? ccc})? ddd;
+(int, int)? aaa;
+(int aaa, int bbb)? bbb;
+(int aaa, int, {String? ccc})? ccc;
+(int, (int, (int, String)))? ddd;
 
-(int aaa, int bbb) foo((String aaaa, String? bbbb) ccc) {
+(int aaa, int bbb) func((String aaaa, String? bbbb) ccc) {
   final ddd = (1, 2, eee: '');
   return (1, 2);
 }
 
 class R {
-  (int aaa, int, {String? ccc})? get ddd => null;
-  final eee = (1, 2, eee: '');
+  (int aaa, int, {String? ccc})? get getter => null;
+  final variable = (1, 2, eee: '');
 }

--- a/test/test_files/records.dart
+++ b/test/test_files/records.dart
@@ -1,0 +1,15 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+(int aaa, int, {String? ccc})? ddd;
+
+(int aaa, int bbb) foo((String aaaa, String? bbbb) ccc) {
+  final ddd = (1, 2, eee: '');
+  return (1, 2);
+}
+
+class R {
+  (int aaa, int, {String? ccc})? get ddd => null;
+  final eee = (1, 2, eee: '');
+}


### PR DESCRIPTION
@devoncarew the existing grammar parses this syntax as expected without any changes, this is just adding some goldens to ensure that continues to be the case.

While adding this, I noticed the copyright headers say "Copyright 2022 The Chromium Authors" (and not "Dart authors") because I took the original sample files from flutter/devtools (which has that in all of its headers). Should these be changed?