### PR TITLE
Fix handling of type params/args w/ extends, and get/set as function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (2022-12-07)
+
+- Improved handling of nested type parameters/arguments.
+- Improved handling of class declarations with both type arguments and `extends`.
+- Fixed handling of `get` and `set` as function names.
+
 ## 1.0.0 (2022-07-26)
 
 - Added an initial version number to the `grammars/dart.json` to help compare versions for projects using a copy of this file.

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"fileTypes": [
 		"dart"
 	],
@@ -59,6 +59,9 @@
 		},
 		{
 			"include": "#constants-and-special-vars"
+		},
+		{
+			"include": "#operators"
 		},
 		{
 			"include": "#strings"
@@ -234,27 +237,26 @@
 		"class-identifier": {
 			"patterns": [
 				{
-					"name": "storage.type.primitive.dart",
-					"match": "\\bvoid\\b"
+					"match": "bool\\b|num\\b|int\\b|double\\b|dynamic\\b",
+					"name": "support.class.dart"
 				},
 				{
-					"name": "support.class.dart",
-					"match": "\\b(bool|num|int|double|dynamic)\\b"
+					"match": "void\\b",
+					"name": "storage.type.primitive.dart"
 				},
 				{
-					"match": "\\b([_$]*[A-Z][a-zA-Z0-9_$]*)(<(?:[a-zA-Z0-9_$<>?]|,\\s*|\\s+extends\\s+)+>)?",
-					"captures": {
+					"begin": "(?<![a-zA-Z0-9_$])([_$]*[A-Z][a-zA-Z0-9_$]*)\\b",
+					"end": "(?!<)",
+					"beginCaptures": {
 						"1": {
 							"name": "support.class.dart"
-						},
-						"2": {
-							"patterns": [
-								{
-									"include": "#type-args"
-								}
-							]
 						}
-					}
+					},
+					"patterns": [
+						{
+							"include": "#type-args"
+						}
+					]
 				}
 			]
 		},
@@ -295,7 +297,7 @@
 					"include": "#class-identifier"
 				},
 				{
-					"match": "[\\s,]+"
+					"match": ","
 				},
 				{
 					"name": "keyword.declaration.dart",
@@ -331,8 +333,20 @@
 				},
 				{
 					"name": "keyword.declaration.dart",
-					"match": "(?<!\\$)\\b(abstract|class|enum|extends|extension|external|factory|implements|get|mixin|native|operator|set|typedef|with|covariant)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(abstract|class|enum|extends|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
 				},
+				{
+					"name": "storage.modifier.dart",
+					"match": "(?<!\\$)\\b(static|final|const|required|late)\\b(?!\\$)"
+				},
+				{
+					"name": "storage.type.primitive.dart",
+					"match": "(?<!\\$)\\b(?:void|var)\\b(?!\\$)"
+				}
+			]
+		},
+		"operators": {
+			"patterns": [
 				{
 					"name": "keyword.operator.dart",
 					"match": "(?<!\\$)\\b(is\\!?)\\b(?!\\$)"
@@ -376,14 +390,6 @@
 				{
 					"name": "keyword.operator.logical.dart",
 					"match": "(!|&&|\\|\\|)"
-				},
-				{
-					"name": "storage.modifier.dart",
-					"match": "(?<!\\$)\\b(static|final|const|required|late)\\b(?!\\$)"
-				},
-				{
-					"name": "storage.type.primitive.dart",
-					"match": "(?<!\\$)\\b(?:void|var)\\b(?!\\$)"
 				}
 			]
 		},

--- a/test/goldens/classes.dart.golden
+++ b/test/goldens/classes.dart.golden
@@ -105,11 +105,14 @@
 #^^^^^ keyword.declaration.dart
 #      ^^^^^^^ support.class.dart
 >
->mixin MyMixin2 on Class1 {}
+>mixin MyMixin2<T> on Class1 {}
 #^^^^^ keyword.declaration.dart
 #      ^^^^^^^^ support.class.dart
-#               ^^ keyword.control.catch-exception.dart
-#                  ^^^^^^ support.class.dart
+#              ^ other.source.dart
+#               ^ support.class.dart
+#                ^ other.source.dart
+#                  ^^ keyword.control.catch-exception.dart
+#                     ^^^^^^ support.class.dart
 >
 >extension on String {}
 #^^^^^^^^^ keyword.declaration.dart
@@ -173,3 +176,27 @@
 #        ^ other.source.dart
 #         ^ support.class.dart
 #          ^ other.source.dart
+>
+>class A3<T> implements A1<T> {}
+#^^^^^ keyword.declaration.dart
+#      ^^ support.class.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#          ^ other.source.dart
+#            ^^^^^^^^^^ keyword.declaration.dart
+#                       ^^ support.class.dart
+#                         ^ other.source.dart
+#                          ^ support.class.dart
+#                           ^ other.source.dart
+>
+>class A4<T> with MyMixin2<T> {}
+#^^^^^ keyword.declaration.dart
+#      ^^ support.class.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#          ^ other.source.dart
+#            ^^^^ keyword.declaration.dart
+#                 ^^^^^^^^ support.class.dart
+#                         ^ other.source.dart
+#                          ^ support.class.dart
+#                           ^ other.source.dart

--- a/test/goldens/classes.dart.golden
+++ b/test/goldens/classes.dart.golden
@@ -76,10 +76,10 @@
 #       ^^^^^^^ support.class.dart
 >  void get() {}
 #  ^^^^ storage.type.primitive.dart
-#       ^^^ keyword.declaration.dart
+#       ^^^ entity.name.function.dart
 >  void set() {}
 #  ^^^^ storage.type.primitive.dart
-#       ^^^ keyword.declaration.dart
+#       ^^^ entity.name.function.dart
 >
 >  String? _foo;
 #  ^^^^^^ support.class.dart
@@ -176,6 +176,11 @@
 #        ^ other.source.dart
 #         ^ support.class.dart
 #          ^ other.source.dart
+#            ^^^^^^^ keyword.declaration.dart
+#                    ^^ support.class.dart
+#                      ^ other.source.dart
+#                       ^ support.class.dart
+#                        ^ other.source.dart
 >
 >class A3<T> implements A1<T> {}
 #^^^^^ keyword.declaration.dart

--- a/test/goldens/functions.dart.golden
+++ b/test/goldens/functions.dart.golden
@@ -60,7 +60,7 @@
 #        ^^^^ support.class.dart
 #            ^ other.source.dart
 #             ^^ support.class.dart
-#               ^ other.source.dart
+#               ^^ other.source.dart
 #                  ^^^^^^^^^^^^^^ entity.name.function.dart
 #                                ^ other.source.dart
 #                                 ^^ support.class.dart

--- a/test/goldens/misc.dart.golden
+++ b/test/goldens/misc.dart.golden
@@ -48,6 +48,12 @@
 #        ^ other.source.dart
 #         ^^^^^^ support.class.dart
 #               ^ other.source.dart
+#                  ^^^^ support.class.dart
+#                      ^ other.source.dart
+#                       ^^^^ support.class.dart
+#                           ^ other.source.dart
+#                            ^^^^^^ support.class.dart
+#                                  ^^^ other.source.dart
 #                                     ^ keyword.operator.ternary.dart
 #                                                          ^ punctuation.terminator.dart
 >

--- a/test/goldens/misc.dart.golden
+++ b/test/goldens/misc.dart.golden
@@ -41,6 +41,16 @@
 #                                                 ^^^^^^ support.class.dart
 #                                                          ^ punctuation.terminator.dart
 >
+>Map<List<String>, List<List<String>>>? nestedTypeArguments;
+#^^^ support.class.dart
+#   ^ other.source.dart
+#    ^^^^ support.class.dart
+#        ^ other.source.dart
+#         ^^^^^^ support.class.dart
+#               ^ other.source.dart
+#                                     ^ keyword.operator.ternary.dart
+#                                                          ^ punctuation.terminator.dart
+>
 >void misc(int a, {required int b}) {
 #^^^^ storage.type.primitive.dart
 #     ^^^^ entity.name.function.dart

--- a/test/goldens/parameters.dart.golden
+++ b/test/goldens/parameters.dart.golden
@@ -39,7 +39,7 @@
 #          ^ other.source.dart
 #           ^^^^^^ support.class.dart
 #                   ^^^^^^ support.class.dart
-#                         ^ other.source.dart
+#                         ^^ other.source.dart
 #                            ^^^^^^^^ support.class.dart
 #                                     ^^^^^^ support.class.dart
 #                                                ^ punctuation.comma.dart

--- a/test/test_files/classes.dart
+++ b/test/test_files/classes.dart
@@ -34,7 +34,7 @@ class MyClass {
 
 mixin MyMixin {}
 
-mixin MyMixin2 on Class1 {}
+mixin MyMixin2<T> on Class1 {}
 
 extension on String {}
 
@@ -52,3 +52,7 @@ class my_lowercase_class {
 class A1<T> {}
 
 class A2<T> extends A1<T> {}
+
+class A3<T> implements A1<T> {}
+
+class A4<T> with MyMixin2<T> {}

--- a/test/test_files/misc.dart
+++ b/test/test_files/misc.dart
@@ -10,6 +10,8 @@ typedef StringAlias = String;
 typedef void FunctionAlias1(String a, String b);
 typedef FunctionAlias2 = void Function(String a, String b);
 
+Map<List<String>, List<List<String>>>? nestedTypeArguments;
+
 void misc(int a, {required int b}) {
   assert(true);
   assert(1 == 1, 'fail');


### PR DESCRIPTION
Fixes https://github.com/Dart-Code/Dart-Code/issues/4216.

@devoncarew this improves how type args are parsed slightly which fixes some issues where the type args would eat much more than it should, preventing some colouring from appearing.

Before:

![image](https://user-images.githubusercontent.com/1078012/206181873-a9ba9669-90c0-4062-b26b-d018e3f5e584.png)

After:

<img width="617" alt="Screenshot 2022-12-07 at 12 41 47" src="https://user-images.githubusercontent.com/1078012/206182032-d9efcb95-c9ad-44d5-9471-67ea67316e63.png">

Additionally, it handles get/set as function names better (more closely matching semantic tokens).

Before:

<img width="343" alt="Screenshot 2022-12-07 at 12 43 36" src="https://user-images.githubusercontent.com/1078012/206182395-59b9f88d-d1a8-40d1-9360-e143c12a0100.png">

After:

<img width="335" alt="Screenshot 2022-12-07 at 12 43 21" src="https://user-images.githubusercontent.com/1078012/206182366-20d13502-a304-4fb7-98d2-67387c99fe2d.png">

I added some additional tests in the first commit (with corresponding golden updates for the current behaviour) and then the grammar change + golden changes they result in in the subsequent commit.