### PR TITLE
Add support for inline classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2 (2023-05-09)
+
+- Added support for `inline` keyword.
+
 ## 1.2.1 (2023-05-04)
 
 - Fixed highlighting of comments inside type arguments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.2 (2023-05-09)
+## 1.2.2 (2023-06-28)
 
 - Added support for `inline` keyword.
 

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -336,7 +336,7 @@
 				},
 				{
 					"name": "keyword.declaration.dart",
-					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|inline class|class|enum|extends|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
 				},
 				{
 					"name": "storage.modifier.dart",

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"fileTypes": [
 		"dart"
 	],

--- a/test/goldens/inline.dart.golden
+++ b/test/goldens/inline.dart.golden
@@ -31,12 +31,12 @@
 #               ^ constant.numeric.dart
 #                ^ punctuation.terminator.dart
 >
->int get inline = 1;
+>int get inline => 1;
 #^^^ support.class.dart
 #    ^^^ keyword.declaration.dart
-#               ^ keyword.operator.assignment.dart
-#                 ^ constant.numeric.dart
-#                  ^ punctuation.terminator.dart
+#               ^^ keyword.operator.closure.dart
+#                  ^ constant.numeric.dart
+#                   ^ punctuation.terminator.dart
 >set inline(int value) {}
 #^^^ keyword.declaration.dart
 #    ^^^^^^ entity.name.function.dart

--- a/test/goldens/inline.dart.golden
+++ b/test/goldens/inline.dart.golden
@@ -1,0 +1,53 @@
+>// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// for details. All rights reserved. Use of this source code is governed by a
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>// BSD-style license that can be found in the LICENSE file.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>
+>inline class MyInt {
+#^^^^^^^^^^^^ keyword.declaration.dart
+#             ^^^^^ support.class.dart
+>  final int it;
+#  ^^^^^ storage.modifier.dart
+#        ^^^ support.class.dart
+#              ^ punctuation.terminator.dart
+>  MyInt(this.it);
+#  ^^^^^ support.class.dart
+#        ^^^^ variable.language.dart
+#            ^ punctuation.dot.dart
+#                ^ punctuation.terminator.dart
+>  void foo() { print('MyInt.foo'); }
+#  ^^^^ storage.type.primitive.dart
+#       ^^^ entity.name.function.dart
+#               ^^^^^ entity.name.function.dart
+#                     ^^^^^^^^^^^ string.interpolated.single.dart
+#                                 ^ punctuation.terminator.dart
+>}
+>
+>final inline = 1;
+#^^^^^ storage.modifier.dart
+#             ^ keyword.operator.assignment.dart
+#               ^ constant.numeric.dart
+#                ^ punctuation.terminator.dart
+>
+>int get inline = 1;
+#^^^ support.class.dart
+#    ^^^ keyword.declaration.dart
+#               ^ keyword.operator.assignment.dart
+#                 ^ constant.numeric.dart
+#                  ^ punctuation.terminator.dart
+>set inline(int value) {}
+#^^^ keyword.declaration.dart
+#    ^^^^^^ entity.name.function.dart
+#           ^^^ support.class.dart
+>
+>void inline() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^ entity.name.function.dart
+>  var inline = 1;
+#  ^^^ storage.type.primitive.dart
+#             ^ keyword.operator.assignment.dart
+#               ^ constant.numeric.dart
+#                ^ punctuation.terminator.dart
+>}

--- a/test/test_files/inline.dart
+++ b/test/test_files/inline.dart
@@ -10,7 +10,7 @@ inline class MyInt {
 
 final inline = 1;
 
-int get inline = 1;
+int get inline => 1;
 set inline(int value) {}
 
 void inline() {

--- a/test/test_files/inline.dart
+++ b/test/test_files/inline.dart
@@ -1,0 +1,18 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+inline class MyInt {
+  final int it;
+  MyInt(this.it);
+  void foo() { print('MyInt.foo'); }
+}
+
+final inline = 1;
+
+int get inline = 1;
+set inline(int value) {}
+
+void inline() {
+  var inline = 1;
+}


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/49734 and https://github.com/dart-lang/language/blob/master/accepted/future-releases/inline-classes/feature-specification.md.

Inline is only detected as part of class, since the spec says:

> The token `inline` is not made a built-in identifier: the reserved word `class` that occurs right after `inline` serves to disambiguate the inline class declaration with a fixed lookahead.
