### PR TITLE
Fix highlighting of comments inside type args/parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1 (2023-05-04)
+
+- Fixed highlighting of comments inside type arguments.
+
 ## 1.2.0 (2023-01-30)
 
 - Added support for class modifiers.

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"fileTypes": [
 		"dart"
 	],
@@ -302,6 +302,9 @@
 				{
 					"name": "keyword.declaration.dart",
 					"match": "extends"
+				},
+				{
+					"include": "#comments"
 				}
 			]
 		},

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -102,3 +102,23 @@
 >var h;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
+>
+>class A<dynamic /* comment */ > {
+#^^^^^ keyword.declaration.dart
+#      ^ support.class.dart
+#       ^ other.source.dart
+#        ^^^^^^^ support.class.dart
+#                              ^ other.source.dart
+>  void b<dynamic /* comment */ >() {}
+#  ^^^^ storage.type.primitive.dart
+#        ^ keyword.operator.comparison.dart
+#         ^^^^^^^ support.class.dart
+#                 ^^^^^^^^^^^^^ comment.block.dart
+#                               ^ keyword.operator.comparison.dart
+>  Future<dynamic /* comment */ > c() {}
+#  ^^^^^^ support.class.dart
+#        ^ other.source.dart
+#         ^^^^^^^ support.class.dart
+#                               ^ other.source.dart
+#                                 ^ entity.name.function.dart
+>}

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -108,6 +108,7 @@
 #      ^ support.class.dart
 #       ^ other.source.dart
 #        ^^^^^^^ support.class.dart
+#                ^^^^^^^^^^^^^ comment.block.dart
 #                              ^ other.source.dart
 >  void b<dynamic /* comment */ >() {}
 #  ^^^^ storage.type.primitive.dart
@@ -119,6 +120,7 @@
 #  ^^^^^^ support.class.dart
 #        ^ other.source.dart
 #         ^^^^^^^ support.class.dart
+#                 ^^^^^^^^^^^^^ comment.block.dart
 #                               ^ other.source.dart
 #                                 ^ entity.name.function.dart
 >}

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -46,3 +46,8 @@ var g;
 /// Dartdoc with reference to [a].
 /// And a link to [example.org](http://example.org/).
 var h;
+
+class A<dynamic /* comment */ > {
+  void b<dynamic /* comment */ >() {}
+  Future<dynamic /* comment */ > c() {}
+}


### PR DESCRIPTION
First commit adds a golden showing the current behaviour, and the second commit includes the fix and the diff it makes to the tests.

Fixes https://github.com/dart-lang/dart-syntax-highlight/issues/45.