### PR TITLE
Remove useless `"name"`

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -412,8 +412,7 @@
 					"end": "\\}",
 					"patterns": [
 						{
-							"include": "#constants-and-special-vars",
-							"name": "variable.parameter.dart"
+							"include": "#constants-and-special-vars"
 						},
 						{
 							"include": "#strings"


### PR DESCRIPTION
- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

When inside a `"patterns"` array
`"name"` needs to be paired with `"match"` or `"begin"`
currently it is useless with `"include"`
https://github.com/dart-lang/dart-syntax-highlight/blob/d4ba2801445e713de55949ded4afae313b7eab4d/grammars/dart.json#L416

This PR will not affect the final grammar in any way

I assume its a remnant of a copy&paste from a few lines down
https://github.com/dart-lang/dart-syntax-highlight/blob/d4ba2801445e713de55949ded4afae313b7eab4d/grammars/dart.json#L422