### PR TITLE
Include opening `$` in identifier interpolation scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.4 (2023-11-26)
+
+- Include the opening `$` of a simple identifier string interpolation
+  inside the `string.interpolated.expression.dart` scope.
+
 ## 1.2.3 (2023-09-11)
 
 - Removed support for `inline class` keyword and added support for `extension type`.

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"fileTypes": [
 		"dart"
 	],

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -399,6 +399,7 @@
 		"string-interp": {
 			"patterns": [
 				{
+					"name": "string.interpolated.expression.dart",
 					"match": "\\$([a-zA-Z0-9_]+)",
 					"captures": {
 						"1": {

--- a/test/goldens/literals.dart.golden
+++ b/test/goldens/literals.dart.golden
@@ -27,8 +27,9 @@
 #            ^ keyword.operator.assignment.dart
 #               ^^ string.interpolated.single.dart
 #                 ^ punctuation.comma.dart
-#                   ^^ string.interpolated.single.dart
-#                     ^ string.interpolated.single.dart variable.parameter.dart
+#                   ^ string.interpolated.single.dart
+#                    ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                     ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                      ^ string.interpolated.single.dart
 #                        ^ punctuation.terminator.dart
 >const list4 = <String>['', '$a'];
@@ -39,8 +40,9 @@
 #                     ^ keyword.operator.comparison.dart
 #                       ^^ string.interpolated.single.dart
 #                         ^ punctuation.comma.dart
-#                           ^^ string.interpolated.single.dart
-#                             ^ string.interpolated.single.dart variable.parameter.dart
+#                           ^ string.interpolated.single.dart
+#                            ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                             ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                              ^ string.interpolated.single.dart
 #                                ^ punctuation.terminator.dart
 >
@@ -60,8 +62,9 @@
 #           ^ keyword.operator.assignment.dart
 #              ^^ string.interpolated.single.dart
 #                ^ punctuation.comma.dart
-#                  ^^ string.interpolated.single.dart
-#                    ^ string.interpolated.single.dart variable.parameter.dart
+#                  ^ string.interpolated.single.dart
+#                   ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const set4 = <String>{'', '$a'};
@@ -72,8 +75,9 @@
 #                    ^ keyword.operator.comparison.dart
 #                      ^^ string.interpolated.single.dart
 #                        ^ punctuation.comma.dart
-#                          ^^ string.interpolated.single.dart
-#                            ^ string.interpolated.single.dart variable.parameter.dart
+#                          ^ string.interpolated.single.dart
+#                           ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                            ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                             ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >
@@ -91,8 +95,9 @@
 #           ^ keyword.operator.assignment.dart
 #              ^^ string.interpolated.single.dart
 #                ^ keyword.operator.ternary.dart
-#                  ^^ string.interpolated.single.dart
-#                    ^ string.interpolated.single.dart variable.parameter.dart
+#                  ^ string.interpolated.single.dart
+#                   ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const map3 = <String, String>{'': '$a'};
@@ -105,7 +110,8 @@
 #                            ^ keyword.operator.comparison.dart
 #                              ^^ string.interpolated.single.dart
 #                                ^ keyword.operator.ternary.dart
-#                                  ^^ string.interpolated.single.dart
-#                                    ^ string.interpolated.single.dart variable.parameter.dart
+#                                  ^ string.interpolated.single.dart
+#                                   ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                                     ^ string.interpolated.single.dart
 #                                       ^ punctuation.terminator.dart

--- a/test/goldens/string_interpolation.dart.golden
+++ b/test/goldens/string_interpolation.dart.golden
@@ -23,8 +23,9 @@
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                      ^^ string.interpolated.single.dart constant.character.escape.dart
-#                        ^^^^^^ string.interpolated.single.dart
-#                              ^ string.interpolated.single.dart variable.parameter.dart
+#                        ^^^^^ string.interpolated.single.dart
+#                             ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                              ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
 #                               ^ string.interpolated.single.dart
 #                                 ^ punctuation.terminator.dart
 >  print('the value after \$i is ${i + 1}');


### PR DESCRIPTION
I'm migrating to use TextMate grammars on dart.dev and docs.flutter.dev, but found that while I can highlight the punctuation of expression interpolation with `string.interpolated.expression`, the same didn't work for identifier interpolation.

\cc @DanTup 