### PR TITLE
Don't mark empty backticks as inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.5 (2023-11-27)
+
+- Don't mark empty double backticks as inline code.
+
 ## 1.2.4 (2023-11-26)
 
 - Include the opening `$` of a simple identifier string interpolation

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"fileTypes": [
 		"dart"
 	],
@@ -93,15 +93,7 @@
 					"end": "```"
 				},
 				{
-					"match": "(`.*?`)",
-					"captures": {
-						"0": {
-							"name": "variable.other.source.dart"
-						}
-					}
-				},
-				{
-					"match": "(`.*?`)",
+					"match": "(`[^`]+?`)",
 					"captures": {
 						"0": {
 							"name": "variable.other.source.dart"

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -26,6 +26,19 @@
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
 >
+>/// ``
+#^^^^^^ comment.block.documentation.dart
+>var noInlineCode;
+#^^^ storage.type.primitive.dart
+#                ^ punctuation.terminator.dart
+>
+>/// ` `
+#^^^^ comment.block.documentation.dart
+#    ^^^ comment.block.documentation.dart variable.other.source.dart
+>var inlineCode;
+#^^^ storage.type.primitive.dart
+#              ^ punctuation.terminator.dart
+>
 >/*
 #^^ comment.block.dart
 > * Old-style dartdoc

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -32,12 +32,19 @@
 #^^^ storage.type.primitive.dart
 #                ^ punctuation.terminator.dart
 >
->/// ` `
+>/// `Stream<int>`
 #^^^^ comment.block.documentation.dart
-#    ^^^ comment.block.documentation.dart variable.other.source.dart
+#    ^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var inlineCode;
 #^^^ storage.type.primitive.dart
 #              ^ punctuation.terminator.dart
+>
+>/// ` `
+#^^^^ comment.block.documentation.dart
+#    ^^^ comment.block.documentation.dart variable.other.source.dart
+>var inlineCodeJustWhitespace;
+#^^^ storage.type.primitive.dart
+#                            ^ punctuation.terminator.dart
 >
 >/*
 #^^ comment.block.dart

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -14,8 +14,11 @@ var a;
 /// ``
 var noInlineCode;
 
-/// ` `
+/// `Stream<int>`
 var inlineCode;
+
+/// ` `
+var inlineCodeJustWhitespace;
 
 /*
  * Old-style dartdoc

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -11,6 +11,12 @@
 /// ...
 var a;
 
+/// ``
+var noInlineCode;
+
+/// ` `
+var inlineCode;
+
 /*
  * Old-style dartdoc
  *


### PR DESCRIPTION
Also removes what appears to be a duplicate pattern entry for this match. Let me know if it exists for a reason.
