### PR TITLE
Fix highlighting of generic methods named get/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.6 (2024-01-25)
+
+- Don't highlight methods named `get`/`set` with type parameters as keywords.
+
 ## 1.2.5 (2023-11-27)
 
 - Don't mark empty double backticks as inline code.

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"fileTypes": [
 		"dart"
 	],
@@ -328,7 +328,7 @@
 				},
 				{
 					"name": "keyword.declaration.dart",
-					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension type|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension type|extension|external|factory|implements|get(?![(<])|mixin|native|operator|set(?![(<])|typedef|with|covariant)\\b(?!\\$)"
 				},
 				{
 					"name": "storage.modifier.dart",

--- a/test/goldens/classes.dart.golden
+++ b/test/goldens/classes.dart.golden
@@ -77,9 +77,21 @@
 >  void get() {}
 #  ^^^^ storage.type.primitive.dart
 #       ^^^ entity.name.function.dart
+>  void get<T>() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^ entity.name.function.dart
+#          ^ other.source.dart
+#           ^ support.class.dart
+#            ^ other.source.dart
 >  void set() {}
 #  ^^^^ storage.type.primitive.dart
 #       ^^^ entity.name.function.dart
+>  void set<T>() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^ entity.name.function.dart
+#          ^ other.source.dart
+#           ^ support.class.dart
+#            ^ other.source.dart
 >
 >  String? _foo;
 #  ^^^^^^ support.class.dart
@@ -100,6 +112,25 @@
 #                                 ^ keyword.operator.assignment.dart
 #                                        ^ punctuation.terminator.dart
 >}
+>
+>void get() {}
+#^^^^ storage.type.primitive.dart
+#     ^^^ entity.name.function.dart
+>void get<T>() {}
+#^^^^ storage.type.primitive.dart
+#     ^^^ entity.name.function.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#          ^ other.source.dart
+>void set() {}
+#^^^^ storage.type.primitive.dart
+#     ^^^ entity.name.function.dart
+>void set<T>() {}
+#^^^^ storage.type.primitive.dart
+#     ^^^ entity.name.function.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#          ^ other.source.dart
 >
 >mixin MyMixin {}
 #^^^^^ keyword.declaration.dart

--- a/test/test_files/classes.dart
+++ b/test/test_files/classes.dart
@@ -25,12 +25,19 @@ class MyClass {
   void method1() {}
   void Method2() {}
   void get() {}
+  void get<T>() {}
   void set() {}
+  void set<T>() {}
 
   String? _foo;
   String? get foo => _foo;
   set foo(String? value) => _foo = value;
 }
+
+void get() {}
+void get<T>() {}
+void set() {}
+void set<T>() {}
 
 mixin MyMixin {}
 


### PR DESCRIPTION
This fixes highlighting of methods named get/set that have type parameters. We would previously match `get`/`set` as keywords unless followed by a `(`, but now we check for both `(` and `<`.

## Before / After

![Screenshot 2024-01-25 130913](https://github.com/dart-lang/dart-syntax-highlight/assets/1078012/c76f99d5-f18d-4071-959f-2fc5286f4c0c)

See https://github.com/Dart-Code/Dart-Code/issues/4957