### PR TITLE
define keyword.control.return.dart

### DIFF
--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -312,7 +312,7 @@
 				},
 				{
 					"name": "keyword.control.dart",
-					"match": "(?<!\\$)\\b(break|case|continue|default|do|else|for|if|in|return|switch|while|when)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(break|case|continue|default|do|else|for|if|in|switch|while|when)\\b(?!\\$)"
 				},
 				{
 					"name": "keyword.control.dart",
@@ -325,6 +325,10 @@
 				{
 					"name": "keyword.control.new.dart",
 					"match": "(?<!\\$)\\b(new)\\b(?!\\$)"
+				},
+				{
+					"name": "keyword.control.return.dart",
+					"match": "(?<!\\$)\\b(return)\\b(?!\\$)"
 				},
 				{
 					"name": "keyword.declaration.dart",

--- a/test/goldens/control.dart.golden
+++ b/test/goldens/control.dart.golden
@@ -52,7 +52,7 @@
 #           ^ punctuation.terminator.dart
 >    }
 >    return;
-#    ^^^^^^ keyword.control.dart
+#    ^^^^^^ keyword.control.return.dart
 #          ^ punctuation.terminator.dart
 >  }
 >
@@ -94,7 +94,7 @@
 #    ^^^^^^^ keyword.control.dart
 #           ^ keyword.operator.ternary.dart
 >      return;
-#      ^^^^^^ keyword.control.dart
+#      ^^^^^^ keyword.control.return.dart
 #            ^ punctuation.terminator.dart
 >  }
 >}

--- a/test/goldens/functions.dart.golden
+++ b/test/goldens/functions.dart.golden
@@ -26,7 +26,7 @@
 #^^^^ storage.type.primitive.dart
 #     ^^^^^^^ entity.name.function.dart
 >  return;
-#  ^^^^^^ keyword.control.dart
+#  ^^^^^^ keyword.control.return.dart
 #        ^ punctuation.terminator.dart
 >}
 >
@@ -69,7 +69,7 @@
 #                                                ^^^^^^ support.class.dart
 #                                                      ^ other.source.dart
 >  return {};
-#  ^^^^^^ keyword.control.dart
+#  ^^^^^^ keyword.control.return.dart
 #           ^ punctuation.terminator.dart
 >}
 >

--- a/test/goldens/patterns.dart.golden
+++ b/test/goldens/patterns.dart.golden
@@ -156,7 +156,7 @@
 #       ^^^^^^^^^^^^^^^^^^^^^ entity.name.function.dart
 #                             ^^^ support.class.dart
 >  return switch (char) {
-#  ^^^^^^ keyword.control.dart
+#  ^^^^^^ keyword.control.return.dart
 #         ^^^^^^ keyword.control.dart
 >    < space => 'control',
 #    ^ keyword.operator.comparison.dart

--- a/test/goldens/records.dart.golden
+++ b/test/goldens/records.dart.golden
@@ -57,7 +57,7 @@
 #                          ^^ string.interpolated.single.dart
 #                             ^ punctuation.terminator.dart
 >  return (1, 2);
-#  ^^^^^^ keyword.control.dart
+#  ^^^^^^ keyword.control.return.dart
 #          ^ constant.numeric.dart
 #           ^ punctuation.comma.dart
 #             ^ constant.numeric.dart


### PR DESCRIPTION
This defines the scope `keyword.control.return.dart` which is useful to color the return key separately. This allows to replicate the feature found in the Eclipse Java editor:

![image](https://github.com/dart-lang/dart-syntax-highlight/assets/426959/45e7ea8e-c108-4af6-b3be-75a70018bf56)

Some other languages already provide separate scopes for the `return` keyword:
- csharp defines `keyword.control.flow.return.cs`
- scss defines `keyword.control.return.scss`
- php even defines separate scopes for all keywords using: `keyword.control.${1:/downcase}.php`
   ```json
   {
     "match": "(?x)\n\\b(\n  break|case|continue|declare|default|die|do|\n  else(if)?|end(declare|for(each)?|if|switch|while)|exit|\n  for(each)?|if|return|switch|use|while|yield\n)\\b",
     "captures": {
       "1": {
         "name": "keyword.control.${1:/downcase}.php"
       }
     }
   },
   ```

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
