### PR TITLE
Enable Windows bot

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: dart-lang/setup-dart@fedb1266e91cf51be2fdb382869461a434b920a3


### PR DESCRIPTION
See https://github.com/dart-lang/dart-syntax-highlight/pull/58.. The tests were failing in weird ways if you have autocrlf=true because the code didn't handle `\r\n` properly.

I have a fix, but I want to see if the Windows bots use autocrlf=true as extra validation (and ongoing testing once that fix lands) so that contributors using autocrlf=true don't hit these kinds of issues.