### PR TITLE
Fix golden tests to work on Windows when git autocrlf=true

### DIFF
--- a/test/support/span_parser.dart
+++ b/test/support/span_parser.dart
@@ -504,7 +504,7 @@ class _MultilineMatcher extends GrammarMatcher {
   }
 
   void _skipLine(LineScanner scanner) {
-    scanner.scan(RegExp('.*\n'));
+    scanner.scan(RegExp('.*\r?\n'));
   }
 
   @override


### PR DESCRIPTION
+ update tests to run with both \n and \r\n files so any issues/differences are picked up on all platforms.

It was noticed in https://github.com/dart-lang/dart-syntax-highlight/pull/58 that the parsing didn't work right for `\r\n`. There were assumptions that everything would always just be `\n`. On Windows, if you had Git set to retain the original line endings everything was fine, but if you had autocrlf=true so they were converted to \r\n the tests would fail (in odd ways because we didn't correctly scan to the ends of lines).

This change makes the tests always run with both sets of line endings, and fixes up the parser (and building of golden text) so handle either line ending correctly.

@jwren @devoncarew 