### PR TITLE
Fix handling of closing braces + use meta.embedded.* for interpolated expressions in string

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+	// To help testing with this project in VS Code, disable
+	// semantic tokens (since they override the grammar) and
+	// enable rainbow brackets (to make it clear if our scopes
+	// are preventing VS Code from matching brackets correctly).
+	"editor.semanticHighlighting.enabled": false,
+	"editor.bracketPairColorization.enabled": true,
+	// Disable formatting because some test files are
+	// formatted specifically to test certain conditions
+	// or to make the results easier to see.
+	"dart.enableSdkFormatter": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.2.8 (2024-04-08)
 
 - Improve handling of braces inside string interpolation so `}` in expressions are not considered the end of the interpolation.
+- Change nested expression scopes from `string.interpolated.expression.dart` to `meta.embedded.expression.dart`.
 
 ## 1.2.7 (2024-02-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.8 (2024-04-08)
+
+- Improve handling of braces inside string interpolation so `}` in expressions are not considered the end of the interpolation.
+
 ## 1.2.7 (2024-02-08)
 
 - Updated the scope for `return` keywords from `keyword.control.dart` to `keyword.control.return.dart`.

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -432,16 +432,6 @@
 					"end": "\\}",
 					"patterns": [
 						{
-							"include": "#constants-and-special-vars"
-						},
-						{
-							"include": "#strings"
-						},
-						{
-							"name": "variable.parameter.dart",
-							"match": "[a-zA-Z0-9_]+"
-						},
-						{
 							"include": "#expression"
 						}
 					]

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.7",
+	"version": "1.2.8",
 	"fileTypes": [
 		"dart"
 	],
@@ -392,10 +392,33 @@
 				}
 			]
 		},
+		"expression": {
+			"patterns": [
+				{
+					"include": "#constants-and-special-vars"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"name": "variable.parameter.dart",
+					"match": "[a-zA-Z0-9_]+"
+				},
+				{
+					"begin": "\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
 		"string-interp": {
 			"patterns": [
 				{
-					"name": "string.interpolated.expression.dart",
+					"name": "meta.embedded.expression.dart",
 					"match": "\\$([a-zA-Z0-9_]+)",
 					"captures": {
 						"1": {
@@ -404,7 +427,7 @@
 					}
 				},
 				{
-					"name": "string.interpolated.expression.dart",
+					"name": "meta.embedded.expression.dart",
 					"begin": "\\$\\{",
 					"end": "\\}",
 					"patterns": [
@@ -417,6 +440,9 @@
 						{
 							"name": "variable.parameter.dart",
 							"match": "[a-zA-Z0-9_]+"
+						},
+						{
+							"include": "#expression"
 						}
 					]
 				},

--- a/test/goldens/literals.dart.golden
+++ b/test/goldens/literals.dart.golden
@@ -28,8 +28,8 @@
 #               ^^ string.interpolated.single.dart
 #                 ^ punctuation.comma.dart
 #                   ^ string.interpolated.single.dart
-#                    ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                     ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                    ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                     ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                      ^ string.interpolated.single.dart
 #                        ^ punctuation.terminator.dart
 >const list4 = <String>['', '$a'];
@@ -41,8 +41,8 @@
 #                       ^^ string.interpolated.single.dart
 #                         ^ punctuation.comma.dart
 #                           ^ string.interpolated.single.dart
-#                            ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                             ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                            ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                             ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                              ^ string.interpolated.single.dart
 #                                ^ punctuation.terminator.dart
 >
@@ -63,8 +63,8 @@
 #              ^^ string.interpolated.single.dart
 #                ^ punctuation.comma.dart
 #                  ^ string.interpolated.single.dart
-#                   ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                   ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                    ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const set4 = <String>{'', '$a'};
@@ -76,8 +76,8 @@
 #                      ^^ string.interpolated.single.dart
 #                        ^ punctuation.comma.dart
 #                          ^ string.interpolated.single.dart
-#                           ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                            ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                           ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                            ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                             ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >
@@ -96,8 +96,8 @@
 #              ^^ string.interpolated.single.dart
 #                ^ keyword.operator.ternary.dart
 #                  ^ string.interpolated.single.dart
-#                   ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                   ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                    ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const map3 = <String, String>{'': '$a'};
@@ -111,7 +111,7 @@
 #                              ^^ string.interpolated.single.dart
 #                                ^ keyword.operator.ternary.dart
 #                                  ^ string.interpolated.single.dart
-#                                   ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                                   ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                    ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                                     ^ string.interpolated.single.dart
 #                                       ^ punctuation.terminator.dart

--- a/test/goldens/string_interpolation.dart.golden
+++ b/test/goldens/string_interpolation.dart.golden
@@ -96,3 +96,234 @@
 #                                   ^^ string.interpolated.single.dart
 #                                      ^ punctuation.terminator.dart
 >}
+>
+>void nestedBraces() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^^^^^^ entity.name.function.dart
+>  print(   '${    { " {} ${ "}" } {}" }      }'  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.single.dart
+#            ^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                    ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                                     ^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                       ^^^^^^^^ string.interpolated.single.dart
+#                                                  ^ punctuation.terminator.dart
+>  print(   '${    {}      }'  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.single.dart
+#            ^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                    ^^^^^^^^ string.interpolated.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(   '${    "{}"    }'  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.single.dart
+#            ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                  ^^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                      ^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                           ^ string.interpolated.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(   '${    "{"     }'  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.single.dart
+#            ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                  ^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                           ^ string.interpolated.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(   '${    "}"     }'  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.single.dart
+#            ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                  ^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                           ^ string.interpolated.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(   '${    {}      }'  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.single.dart
+#            ^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#                    ^^^^^^^^ string.interpolated.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(   "${    {}      }"  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.double.dart
+#            ^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#                    ^^^^^^^^ string.interpolated.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(   "${    "{}"    }"  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#                           ^ string.interpolated.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(   "${    "{"     }"  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#                           ^ string.interpolated.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(   "${    "}"     }"  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#                           ^ string.interpolated.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(   "${    {}      }"  );
+#  ^^^^^ entity.name.function.dart
+#           ^ string.interpolated.double.dart
+#            ^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#                    ^^^^^^^^ string.interpolated.double.dart
+#                               ^ punctuation.terminator.dart
+>  print( '''${    {}      }''');
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.single.dart
+#            ^^^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                    ^^^^^^^^^^ string.interpolated.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print( '''${    "{}"    }''');
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.single.dart
+#            ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                  ^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                      ^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                           ^^^ string.interpolated.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print( '''${    "{"     }''');
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.single.dart
+#            ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                  ^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                           ^^^ string.interpolated.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print( '''${    "}"     }''');
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.single.dart
+#            ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                  ^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                           ^^^ string.interpolated.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print( '''${    {}      }''');
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.single.dart
+#            ^^^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#                    ^^^^^^^^^^ string.interpolated.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print( """${    {}      }""");
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.double.dart
+#            ^^^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                    ^^^^^^^^^^ string.interpolated.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print( """${    "{}"    }""");
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.double.dart
+#            ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                  ^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                      ^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                           ^^^ string.interpolated.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print( """${    "{"     }""");
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.double.dart
+#            ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                  ^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                           ^^^ string.interpolated.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print( """${    "}"     }""");
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.double.dart
+#            ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                  ^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                           ^^^ string.interpolated.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print( """${    {}      }""");
+#  ^^^^^ entity.name.function.dart
+#         ^^^ string.interpolated.triple.double.dart
+#            ^^^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#                    ^^^^^^^^^^ string.interpolated.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r'${    {}      }'  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r'${    "{}"    }'  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r'${    "{"     }'  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r'${    "}"     }'  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r'${    {}      }'  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r"${    {}      }"  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r"${    '{}'    }"  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r"${    '{'     }"  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r"${    '}'     }"  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(  r"${    {}      }"  );
+#  ^^^^^ entity.name.function.dart
+#          ^^^^^^^^^^^^^^^^^^ string.quoted.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(r'''${    {}      }''');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(r'''${    "{}"    }''');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(r'''${    "{"     }''');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(r'''${    "}"     }''');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(r'''${    {}      }''');
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.single.dart
+#                               ^ punctuation.terminator.dart
+>  print(r"""${    {}      }""");
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(r"""${    "{}"    }""");
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(r"""${    "{"     }""");
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(r"""${    "}"     }""");
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>  print(r"""${    {}      }""");
+#  ^^^^^ entity.name.function.dart
+#        ^^^^^^^^^^^^^^^^^^^^^^ string.quoted.triple.double.dart
+#                               ^ punctuation.terminator.dart
+>}

--- a/test/goldens/string_interpolation.dart.golden
+++ b/test/goldens/string_interpolation.dart.golden
@@ -24,8 +24,8 @@
 #        ^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                      ^^ string.interpolated.single.dart constant.character.escape.dart
 #                        ^^^^^ string.interpolated.single.dart
-#                             ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                              ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                             ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                              ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                               ^ string.interpolated.single.dart
 #                                 ^ punctuation.terminator.dart
 >  print('the value after \$i is ${i + 1}');
@@ -33,11 +33,11 @@
 #        ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                         ^^ string.interpolated.single.dart constant.character.escape.dart
 #                           ^^^^^ string.interpolated.single.dart
-#                                ^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                  ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#                                   ^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                      ^ string.interpolated.single.dart string.interpolated.expression.dart constant.numeric.dart
-#                                       ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                ^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                  ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#                                   ^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                      ^ string.interpolated.single.dart meta.embedded.expression.dart constant.numeric.dart
+#                                       ^ string.interpolated.single.dart meta.embedded.expression.dart
 #                                        ^ string.interpolated.single.dart
 #                                          ^ punctuation.terminator.dart
 >  print('the value of \$i + \$j is ${i + j}');
@@ -47,11 +47,11 @@
 #                        ^^^^ string.interpolated.single.dart
 #                            ^^ string.interpolated.single.dart constant.character.escape.dart
 #                              ^^^^^ string.interpolated.single.dart
-#                                   ^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                     ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#                                      ^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                         ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#                                          ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                   ^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                     ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#                                      ^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                         ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#                                          ^ string.interpolated.single.dart meta.embedded.expression.dart
 #                                           ^ string.interpolated.single.dart
 #                                             ^ punctuation.terminator.dart
 >}
@@ -62,37 +62,37 @@
 >  print('${() {
 #  ^^^^^ entity.name.function.dart
 #        ^ string.interpolated.single.dart
-#         ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#         ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >    return 'Hello';
-#^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#    ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#          ^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#    ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#          ^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >  }}');
-#^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#   ^^ string.interpolated.single.dart
+#^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#    ^ string.interpolated.single.dart
 #      ^ punctuation.terminator.dart
 >  print('print(${() {
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^ string.interpolated.single.dart
-#               ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#               ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >    return 'Hello';
-#^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#    ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#          ^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#    ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#          ^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >  }()})');
-#^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#   ^^^^^ string.interpolated.single.dart
+#^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#      ^^ string.interpolated.single.dart
 #         ^ punctuation.terminator.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
 #        ^ string.interpolated.single.dart
-#         ^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#         ^^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                         ^ string.interpolated.single.dart
 #                           ^ punctuation.terminator.dart
 >  print('print(${(() => 'Hello')()})');
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^ string.interpolated.single.dart
-#               ^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#               ^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                                   ^^ string.interpolated.single.dart
 #                                      ^ punctuation.terminator.dart
 >}
@@ -103,148 +103,148 @@
 >  print(   '${    { " {} ${ "}" } {}" }      }'  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.single.dart
-#            ^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                                     ^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                       ^^^^^^^^ string.interpolated.single.dart
+#            ^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                    ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                                     ^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                              ^ string.interpolated.single.dart
 #                                                  ^ punctuation.terminator.dart
 >  print(   '${    {}      }'  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.single.dart
-#            ^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^^^^^^^^ string.interpolated.single.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                           ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >  print(   '${    "{}"    }'  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.single.dart
-#            ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                  ^^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                      ^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                  ^^^^ string.interpolated.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                      ^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                           ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >  print(   '${    "{"     }'  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.single.dart
-#            ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                  ^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                     ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                  ^^^ string.interpolated.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                           ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >  print(   '${    "}"     }'  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.single.dart
-#            ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                  ^^^ string.interpolated.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                     ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                  ^^^ string.interpolated.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                           ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >  print(   '${    {}      }'  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.single.dart
-#            ^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^^^^^^^^ string.interpolated.single.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                           ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >  print(   "${    {}      }"  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.double.dart
-#            ^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
-#                    ^^^^^^^^ string.interpolated.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart meta.embedded.expression.dart
+#                           ^ string.interpolated.double.dart
 #                               ^ punctuation.terminator.dart
 >  print(   "${    "{}"    }"  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.double.dart
-#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart meta.embedded.expression.dart
 #                           ^ string.interpolated.double.dart
 #                               ^ punctuation.terminator.dart
 >  print(   "${    "{"     }"  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.double.dart
-#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart meta.embedded.expression.dart
 #                           ^ string.interpolated.double.dart
 #                               ^ punctuation.terminator.dart
 >  print(   "${    "}"     }"  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.double.dart
-#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart meta.embedded.expression.dart
 #                           ^ string.interpolated.double.dart
 #                               ^ punctuation.terminator.dart
 >  print(   "${    {}      }"  );
 #  ^^^^^ entity.name.function.dart
 #           ^ string.interpolated.double.dart
-#            ^^^^^^^^ string.interpolated.double.dart string.interpolated.expression.dart
-#                    ^^^^^^^^ string.interpolated.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.double.dart meta.embedded.expression.dart
+#                           ^ string.interpolated.double.dart
 #                               ^ punctuation.terminator.dart
 >  print( '''${    {}      }''');
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.single.dart
-#            ^^^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
-#                    ^^^^^^^^^^ string.interpolated.triple.single.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
+#                           ^^^ string.interpolated.triple.single.dart
 #                               ^ punctuation.terminator.dart
 >  print( '''${    "{}"    }''');
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.single.dart
-#            ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
-#                  ^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                      ^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
+#                  ^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                      ^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
 #                           ^^^ string.interpolated.triple.single.dart
 #                               ^ punctuation.terminator.dart
 >  print( '''${    "{"     }''');
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.single.dart
-#            ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
-#                  ^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                     ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
+#                  ^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
 #                           ^^^ string.interpolated.triple.single.dart
 #                               ^ punctuation.terminator.dart
 >  print( '''${    "}"     }''');
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.single.dart
-#            ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
-#                  ^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                     ^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
+#                  ^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
 #                           ^^^ string.interpolated.triple.single.dart
 #                               ^ punctuation.terminator.dart
 >  print( '''${    {}      }''');
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.single.dart
-#            ^^^^^^^^ string.interpolated.triple.single.dart string.interpolated.expression.dart
-#                    ^^^^^^^^^^ string.interpolated.triple.single.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.triple.single.dart meta.embedded.expression.dart
+#                           ^^^ string.interpolated.triple.single.dart
 #                               ^ punctuation.terminator.dart
 >  print( """${    {}      }""");
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.double.dart
-#            ^^^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
-#                    ^^^^^^^^^^ string.interpolated.triple.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
+#                           ^^^ string.interpolated.triple.double.dart
 #                               ^ punctuation.terminator.dart
 >  print( """${    "{}"    }""");
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.double.dart
-#            ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
-#                  ^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                      ^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
+#                  ^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                      ^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
 #                           ^^^ string.interpolated.triple.double.dart
 #                               ^ punctuation.terminator.dart
 >  print( """${    "{"     }""");
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.double.dart
-#            ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
-#                  ^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                     ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
+#                  ^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
 #                           ^^^ string.interpolated.triple.double.dart
 #                               ^ punctuation.terminator.dart
 >  print( """${    "}"     }""");
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.double.dart
-#            ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
-#                  ^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart string.interpolated.double.dart
-#                     ^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
+#            ^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
+#                  ^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart string.interpolated.double.dart
+#                     ^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
 #                           ^^^ string.interpolated.triple.double.dart
 #                               ^ punctuation.terminator.dart
 >  print( """${    {}      }""");
 #  ^^^^^ entity.name.function.dart
 #         ^^^ string.interpolated.triple.double.dart
-#            ^^^^^^^^ string.interpolated.triple.double.dart string.interpolated.expression.dart
-#                    ^^^^^^^^^^ string.interpolated.triple.double.dart
+#            ^^^^^^^^^^^^^^^ string.interpolated.triple.double.dart meta.embedded.expression.dart
+#                           ^^^ string.interpolated.triple.double.dart
 #                               ^ punctuation.terminator.dart
 >  print(  r'${    {}      }'  );
 #  ^^^^^ entity.name.function.dart

--- a/test/test_files/string_interpolation.dart
+++ b/test/test_files/string_interpolation.dart
@@ -21,3 +21,47 @@ void functions() {
   print('${() => 'Hello'}');
   print('print(${(() => 'Hello')()})');
 }
+
+void nestedBraces() {
+  print(   '${    { " {} ${ "}" } {}" }      }'  );
+  print(   '${    {}      }'  );
+  print(   '${    "{}"    }'  );
+  print(   '${    "{"     }'  );
+  print(   '${    "}"     }'  );
+  print(   '${    {}      }'  );
+  print(   "${    {}      }"  );
+  print(   "${    "{}"    }"  );
+  print(   "${    "{"     }"  );
+  print(   "${    "}"     }"  );
+  print(   "${    {}      }"  );
+  print( '''${    {}      }''');
+  print( '''${    "{}"    }''');
+  print( '''${    "{"     }''');
+  print( '''${    "}"     }''');
+  print( '''${    {}      }''');
+  print( """${    {}      }""");
+  print( """${    "{}"    }""");
+  print( """${    "{"     }""");
+  print( """${    "}"     }""");
+  print( """${    {}      }""");
+  print(  r'${    {}      }'  );
+  print(  r'${    "{}"    }'  );
+  print(  r'${    "{"     }'  );
+  print(  r'${    "}"     }'  );
+  print(  r'${    {}      }'  );
+  print(  r"${    {}      }"  );
+  print(  r"${    '{}'    }"  );
+  print(  r"${    '{'     }"  );
+  print(  r"${    '}'     }"  );
+  print(  r"${    {}      }"  );
+  print(r'''${    {}      }''');
+  print(r'''${    "{}"    }''');
+  print(r'''${    "{"     }''');
+  print(r'''${    "}"     }''');
+  print(r'''${    {}      }''');
+  print(r"""${    {}      }""");
+  print(r"""${    "{}"    }""");
+  print(r"""${    "{"     }""");
+  print(r"""${    "}"     }""");
+  print(r"""${    {}      }""");
+}


### PR DESCRIPTION
Previously we would treat the first `}` in an interpolation expression as the end of the expression. So in:

```dart
var a = " ${ {} }";
```

The interpolation scope would end too soon. Additionally, VS Code's bracket matching used for colouring uses these scopes to know what's a string and what is new code inside a string, so without using `meta.embedded` the colours would be incorrect. Ideally I would have liked to handle that without changing the scope, but I've so far been unable to make it work with custom scopes. I've filed https://github.com/microsoft/vscode/issues/210053 but since other languages are using scope names like `meta.embedded` I think we should go ahead with it too (and we were already mapping to `meta.embedded` for semantic tokens).

Before/after with this change below:

![Screenshot 2024-04-10 150556](https://github.com/dart-lang/dart-syntax-highlight/assets/1078012/496f4e88-4ca5-422d-b646-6be6433513c9)

I've split this into two commits. The first adds additional tests but keeps the grammar the same. The second commit has the fix, along with the changes to goldens for easier comparison of the impact of the changes.