### PR TITLE
Add colouring for macros and augmentations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.9 (2024-04-24)
+
+- Added support for `macro`, `augment library`, `import augment`, `augment`, `augmented`.
+
 ## 1.2.8 (2024-04-08)
 
 - Improve handling of braces inside string interpolation so `}` in expressions are not considered the end of the interpolation.

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.8",
+	"version": "1.2.9",
 	"fileTypes": [
 		"dart"
 	],
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "meta.declaration.dart",
-			"begin": "^\\w*\\b(library|import|part of|part|export)\\b",
+			"begin": "^\\w*\\b(augment\\s+library|library|import\\s+augment|import|part\\s+of|part|export)\\b",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.other.import.dart"
@@ -211,7 +211,7 @@
 				},
 				{
 					"name": "variable.language.dart",
-					"match": "(?<!\\$)\\b(this|super)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(this|super|augmented)\\b(?!\\$)"
 				},
 				{
 					"name": "constant.numeric.dart",
@@ -332,11 +332,11 @@
 				},
 				{
 					"name": "keyword.declaration.dart",
-					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension type|extension|external|factory|implements|get(?![(<])|mixin|native|operator|set(?![(<])|typedef|with|covariant)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension\\s+type|extension|external|factory|implements|get(?![(<])|mixin|native|operator|set(?![(<])|typedef|with|covariant)\\b(?!\\$)"
 				},
 				{
 					"name": "storage.modifier.dart",
-					"match": "(?<!\\$)\\b(static|final|const|required|late)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(macro|augment|static|final|const|required|late)\\b(?!\\$)"
 				},
 				{
 					"name": "storage.type.primitive.dart",

--- a/test/goldens/augmentation.dart.golden
+++ b/test/goldens/augmentation.dart.golden
@@ -1,0 +1,42 @@
+>augment library 'augmented.dart';
+#^^^^^^^^^^^^^^^ meta.declaration.dart keyword.other.import.dart
+#               ^ meta.declaration.dart
+#                ^^^^^^^^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                                ^ meta.declaration.dart punctuation.terminator.dart
+>
+>augment class MyClass {
+#^^^^^^^ storage.modifier.dart
+#        ^^^^^ keyword.declaration.dart
+#              ^^^^^^^ support.class.dart
+>  augment void myMethod() {
+#  ^^^^^^^ storage.modifier.dart
+#          ^^^^ storage.type.primitive.dart
+#               ^^^^^^^^ entity.name.function.dart
+>    augmented();
+#    ^^^^^^^^^ variable.language.dart
+#               ^ punctuation.terminator.dart
+>  }
+>
+>  String get myGetter => augmented;
+#  ^^^^^^ support.class.dart
+#         ^^^ keyword.declaration.dart
+#                      ^^ keyword.operator.closure.dart
+#                         ^^^^^^^^^ variable.language.dart
+#                                  ^ punctuation.terminator.dart
+>  set mySetter(String value) { augmented = value; }
+#  ^^^ keyword.declaration.dart
+#      ^^^^^^^^ entity.name.function.dart
+#               ^^^^^^ support.class.dart
+#                               ^^^^^^^^^ variable.language.dart
+#                                         ^ keyword.operator.assignment.dart
+#                                                ^ punctuation.terminator.dart
+>}
+>
+>augment void myFunction() {
+#^^^^^^^ storage.modifier.dart
+#        ^^^^ storage.type.primitive.dart
+#             ^^^^^^^^^^ entity.name.function.dart
+>  augmented();
+#  ^^^^^^^^^ variable.language.dart
+#             ^ punctuation.terminator.dart
+>}

--- a/test/goldens/augmented.dart.golden
+++ b/test/goldens/augmented.dart.golden
@@ -1,0 +1,27 @@
+>import augment 'augmentation.dart';
+#^^^^^^^^^^^^^^ meta.declaration.dart keyword.other.import.dart
+#              ^ meta.declaration.dart
+#               ^^^^^^^^^^^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                                  ^ meta.declaration.dart punctuation.terminator.dart
+>
+>class MyClass {
+#^^^^^ keyword.declaration.dart
+#      ^^^^^^^ support.class.dart
+>  void myMethod() {}
+#  ^^^^ storage.type.primitive.dart
+#       ^^^^^^^^ entity.name.function.dart
+>  String get myGetter => '';
+#  ^^^^^^ support.class.dart
+#         ^^^ keyword.declaration.dart
+#                      ^^ keyword.operator.closure.dart
+#                         ^^ string.interpolated.single.dart
+#                           ^ punctuation.terminator.dart
+>  set mySetter(String value) {}
+#  ^^^ keyword.declaration.dart
+#      ^^^^^^^^ entity.name.function.dart
+#               ^^^^^^ support.class.dart
+>}
+>
+>void myFunction() {}
+#^^^^ storage.type.primitive.dart
+#     ^^^^^^^^^^ entity.name.function.dart

--- a/test/goldens/classes.dart.golden
+++ b/test/goldens/classes.dart.golden
@@ -259,3 +259,7 @@
 #^^^^^ keyword.declaration.dart
 #      ^^^^^ keyword.declaration.dart
 #            ^^^^^^^^^^^^ support.class.dart
+>macro class MyMacroClass {}
+#^^^^^ storage.modifier.dart
+#      ^^^^^ keyword.declaration.dart
+#            ^^^^^^^^^^^^ support.class.dart

--- a/test/test_files/augmentation.dart
+++ b/test/test_files/augmentation.dart
@@ -1,0 +1,14 @@
+augment library 'augmented.dart';
+
+augment class MyClass {
+  augment void myMethod() {
+    augmented();
+  }
+
+  String get myGetter => augmented;
+  set mySetter(String value) { augmented = value; }
+}
+
+augment void myFunction() {
+  augmented();
+}

--- a/test/test_files/augmented.dart
+++ b/test/test_files/augmented.dart
@@ -1,0 +1,9 @@
+import augment 'augmentation.dart';
+
+class MyClass {
+  void myMethod() {}
+  String get myGetter => '';
+  set mySetter(String value) {}
+}
+
+void myFunction() {}

--- a/test/test_files/classes.dart
+++ b/test/test_files/classes.dart
@@ -69,3 +69,4 @@ interface class MyInterfaceClass {}
 sealed class MySealedClass {}
 final class MyFinalClass {}
 mixin class MyMixinClass {}
+macro class MyMacroClass {}


### PR DESCRIPTION
This adds colouring for the new terms used in macros and augmentations.

The modifiers in the imports/library declarations are coloured the same way as `import`, `library` etc. and `augmented` is treated like `super` (I'm not completely sold on that, but otherwise it would just be uncoloured like other identifiers and I feel like it should stand out as being special).

![image](https://github.com/dart-lang/dart-syntax-highlight/assets/1078012/fa42085c-65da-45fc-bb7a-e1dd237c71c3)

(as usual, the colours may change a little if/when semantic tokens are available)

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

@jwren 
