### PR TITLE
Switch from using "while" to "end" and adjust nested rules accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.0 (2024-10-10)
+
+- Removed use of 'while' in the grammar to avoid some differences in implementations between GitHub and VS Code
+- Improved handling of unclosed code blocks in dartdoc comments
+
 ## 1.3.0 (2024-07-31)
 
 - Added support for digit separators (`_`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.0 (2024-10-10)
+## 1.4.0 (2024-10-30)
 
 - Removed use of 'while' in the grammar to avoid some differences in implementations between GitHub and VS Code
 - Improved handling of unclosed code blocks in dartdoc comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.4.0 (2024-10-30)
+## 1.4.0 (2024-11-14)
 
 - Removed use of 'while' in the grammar to avoid some differences in implementations between GitHub and VS Code
 - Improved handling of unclosed code blocks in dartdoc comments

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"fileTypes": [
 		"dart"
 	],
@@ -69,6 +69,16 @@
 	],
 
 	"repository": {
+		"dartdoc-codeblock-triple": {
+			"begin": "^\\s*///\\s*(?!\\s*```)",
+			"end": "\n",
+			"contentName": "variable.other.source.dart"
+		},
+		"dartdoc-codeblock-block": {
+			"begin": "^\\s*\\*\\s*(?!(\\s*```|\/))",
+			"end": "\n",
+			"contentName": "variable.other.source.dart"
+		},
 		"dartdoc": {
 			"patterns": [
 				{
@@ -80,30 +90,31 @@
 					}
 				},
 				{
-					"match": "^ {4,}(?![ \\*]).*",
-					"captures": {
-						"0": {
-							"name": "variable.name.source.dart"
+					"begin": "^\\s*///\\s*(```)",
+					"end": "^\\s*///\\s*(```)|^(?!\\s*///)",
+					"patterns": [
+						{
+							"include": "#dartdoc-codeblock-triple"
 						}
-					}
+					]
 				},
 				{
-					"contentName": "variable.other.source.dart",
-					"begin": "```.*?$",
-					"end": "```"
-				},
-				{
-					"match": "(`[^`]+?`)",
-					"captures": {
-						"0": {
-							"name": "variable.other.source.dart"
+					"begin": "^\\s*\\*\\s*(```)",
+					"end": "^\\s*\\*\\s*(```)|^(?=\\s*\\*\/)",
+					"patterns": [
+						{
+							"include": "#dartdoc-codeblock-block"
 						}
-					}
+					]
 				},
 				{
-					"match": "(\\* ((    ).*))$",
+					"match": "`[^`\n]+`",
+					"name": "variable.other.source.dart"
+				},
+				{
+					"match": "\\s{4,}(.*)$",
 					"captures": {
-						"2": {
+						"1": {
 							"name": "variable.other.source.dart"
 						}
 					}
@@ -157,7 +168,7 @@
 				{
 					"name": "comment.block.documentation.dart",
 					"begin": "///",
-					"while": "^\\s*///",
+					"end": "^(?!\\s*///)",
 					"patterns": [
 						{
 							"include": "#dartdoc"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ environment:
   sdk: ^3.2.0
 
 dev_dependencies:
-  collection: ^1.18.0
-  dart_flutter_team_lints: ^2.1.1
+  collection: ^1.19.0
+  dart_flutter_team_lints: ^3.2.1
   path: ^1.9.0
-  string_scanner: ^1.2.0
-  test: ^1.25.2
+  string_scanner: ^1.4.0
+  test: ^1.25.8

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -5,15 +5,15 @@
 >// found in the LICENSE file.
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
 >
->/// Multiline dartdoc comment.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>/// Multiline dartdoc comment with triple backticks.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
->/// doc
+>/// code
 #^^^ comment.block.documentation.dart
-#   ^^^^ comment.block.documentation.dart variable.other.source.dart
+#   ^^^^^ comment.block.documentation.dart variable.other.source.dart
 >/// ```
 #^^^ comment.block.documentation.dart
 #   ^ comment.block.documentation.dart variable.other.source.dart
@@ -22,125 +22,204 @@
 #^^^ comment.block.documentation.dart
 >/// ...
 #^^^^^^^ comment.block.documentation.dart
->var a;
+>var doc1;
 #^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#        ^ punctuation.terminator.dart
+>
+>/// Multiline dartdoc comment with unclosed triple backticks.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>/// ```
+#^^^^^^^ comment.block.documentation.dart
+>/// code
+#^^^ comment.block.documentation.dart
+#   ^^^^^ comment.block.documentation.dart variable.other.source.dart
+>var doc2;
+#^^^ storage.type.primitive.dart
+#        ^ punctuation.terminator.dart
+>
+>/// Multiline dartdoc comment with unclosed backticks.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>/// `code
+#^^^^^^^^^ comment.block.documentation.dart
+>var doc3;
+#^^^ storage.type.primitive.dart
+#        ^ punctuation.terminator.dart
+>
+>/// Multiline dartdoc comment with indented code.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>///     code1
+#^^^^^^^^^^^^^ comment.block.documentation.dart
+>///     code2
+#^^^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>///     code3
+#^^^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>/// ...
+#^^^^^^^ comment.block.documentation.dart
+>var doc4;
+#^^^ storage.type.primitive.dart
+#        ^ punctuation.terminator.dart
+>
+>/** Block dartdoc comment with triple backticks.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+> *
+#^^ comment.block.documentation.dart
+> * ```
+#^^^^^^ comment.block.documentation.dart
+> * code
+#^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> * ```
+#^^^ comment.block.documentation.dart variable.other.source.dart
+#   ^^^ comment.block.documentation.dart
+> *
+#^^ comment.block.documentation.dart
+> * ...
+#^^^^^^ comment.block.documentation.dart
+> */
+#^^^ comment.block.documentation.dart
+>var blockDoc1;
+#^^^ storage.type.primitive.dart
+#             ^ punctuation.terminator.dart
+>
+>/** Block dartdoc comment with unclosed triple backticks.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+> *
+#^^ comment.block.documentation.dart
+> * ```
+#^^^^^^ comment.block.documentation.dart
+> * code
+#^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> */
+#^^^ comment.block.documentation.dart variable.other.source.dart
+>var blockDoc2;
+#^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+>
+>/** Block dartdoc comment with unclosed backticks.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> *
+#^^ comment.block.documentation.dart variable.other.source.dart
+> * `code
+#^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> */
+#^^^ comment.block.documentation.dart variable.other.source.dart
+>var blockDoc3;
+#^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+>
+>/** Block dartdoc comment with indented code.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> *
+#^^ comment.block.documentation.dart variable.other.source.dart
+> *     code1
+#^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> *     code2
+#^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> *
+#^^ comment.block.documentation.dart variable.other.source.dart
+> *     code3
+#^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> *
+#^^ comment.block.documentation.dart variable.other.source.dart
+> * ...
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+> */
+#^^^ comment.block.documentation.dart variable.other.source.dart
+>var blockDoc4;
+#^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/// ``
-#^^^^^^ comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var noInlineCode;
-#^^^ storage.type.primitive.dart
-#                ^ punctuation.terminator.dart
+#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/// `Stream<int>`
-#^^^^ comment.block.documentation.dart
-#    ^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var inlineCode;
-#^^^ storage.type.primitive.dart
-#              ^ punctuation.terminator.dart
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/// ` `
-#^^^^ comment.block.documentation.dart
-#    ^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var inlineCodeJustWhitespace;
-#^^^ storage.type.primitive.dart
-#                            ^ punctuation.terminator.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/*
-#^^ comment.block.dart
+#^^ comment.block.documentation.dart variable.other.source.dart
 > * Old-style dartdoc
-#^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+#^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *
-#^^ comment.block.dart
+#^^ comment.block.documentation.dart variable.other.source.dart
 > * ...
-#^^^^^^ comment.block.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > */
-#^^^ comment.block.dart
+#^^^ comment.block.documentation.dart variable.other.source.dart
 >var b;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/* Inline block comment */
-#^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var c;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/**
-#^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart variable.other.source.dart
 > * Nested block
-#^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *
-#^^ comment.block.documentation.dart
+#^^ comment.block.documentation.dart variable.other.source.dart
 > * /**
-#^^^^^^ comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *  * Nested block
-#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *  */
-#^^^^^^ comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > */
-#^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart variable.other.source.dart
 >var d;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/**
-#^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart variable.other.source.dart
 > * Nested
-#^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *
-#^^ comment.block.documentation.dart
+#^^ comment.block.documentation.dart variable.other.source.dart
 > * /* Inline */
-#^^^ comment.block.documentation.dart
-#   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 > */
-#^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart variable.other.source.dart
 >var e;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/* Nested /* Inline */ */
-#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var f;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >// Simple comment
-#^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var g;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >/// Dartdoc with reference to [a].
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
-#                              ^^^ comment.block.documentation.dart variable.name.source.dart
-#                                 ^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >/// And a link to [example.org](http://example.org/).
-#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
-#                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
-#                               ^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var h;
-#^^^ storage.type.primitive.dart
-#     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
->class A<dynamic /* comment */ > {
-#^^^^^ keyword.declaration.dart
-#      ^ support.class.dart
-#       ^ other.source.dart
-#        ^^^^^^^ support.class.dart
-#                ^^^^^^^^^^^^^ comment.block.dart
-#                              ^ other.source.dart
->  void b<dynamic /* comment */ >() {}
-#  ^^^^ storage.type.primitive.dart
-#        ^ keyword.operator.comparison.dart
-#         ^^^^^^^ support.class.dart
-#                 ^^^^^^^^^^^^^ comment.block.dart
-#                               ^ keyword.operator.comparison.dart
->  Future<dynamic /* comment */ > c() {}
-#  ^^^^^^ support.class.dart
-#        ^ other.source.dart
-#         ^^^^^^^ support.class.dart
-#                 ^^^^^^^^^^^^^ comment.block.dart
-#                               ^ other.source.dart
-#                                 ^ entity.name.function.dart
+>class A<T /* comment */ > {
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+>  void b<T /* comment */ >() {}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+>  Future<T /* comment */ > c() {}
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >}
+#^ comment.block.documentation.dart variable.other.source.dart

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -12,12 +12,10 @@
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
 >/// code
-#^^^ comment.block.documentation.dart
-#   ^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^ comment.block.documentation.dart
+#    ^^^^ comment.block.documentation.dart variable.other.source.dart
 >/// ```
-#^^^ comment.block.documentation.dart
-#   ^ comment.block.documentation.dart variable.other.source.dart
-#    ^^^ comment.block.documentation.dart
+#^^^^^^^ comment.block.documentation.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ...
@@ -33,8 +31,8 @@
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
 >/// code
-#^^^ comment.block.documentation.dart
-#   ^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^ comment.block.documentation.dart
+#    ^^^^ comment.block.documentation.dart variable.other.source.dart
 >var doc2;
 #^^^ storage.type.primitive.dart
 #        ^ punctuation.terminator.dart
@@ -54,13 +52,16 @@
 >///
 #^^^ comment.block.documentation.dart
 >///     code1
-#^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^ comment.block.documentation.dart
+#        ^^^^^ comment.block.documentation.dart variable.other.source.dart
 >///     code2
-#^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^ comment.block.documentation.dart
+#        ^^^^^ comment.block.documentation.dart variable.other.source.dart
 >///
 #^^^ comment.block.documentation.dart
 >///     code3
-#^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^ comment.block.documentation.dart
+#        ^^^^^ comment.block.documentation.dart variable.other.source.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ...
@@ -76,10 +77,10 @@
 > * ```
 #^^^^^^ comment.block.documentation.dart
 > * code
-#^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
+#   ^^^^ comment.block.documentation.dart variable.other.source.dart
 > * ```
-#^^^ comment.block.documentation.dart variable.other.source.dart
-#   ^^^ comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart
 > *
 #^^ comment.block.documentation.dart
 > * ...
@@ -97,129 +98,166 @@
 > * ```
 #^^^^^^ comment.block.documentation.dart
 > * code
-#^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
+#   ^^^^ comment.block.documentation.dart variable.other.source.dart
 > */
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 >var blockDoc2;
-#^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#             ^ punctuation.terminator.dart
 >
 >/** Block dartdoc comment with unclosed backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.documentation.dart
 > * `code
-#^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^ comment.block.documentation.dart
 > */
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 >var blockDoc3;
-#^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#             ^ punctuation.terminator.dart
 >
 >/** Block dartdoc comment with indented code.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.documentation.dart
 > *     code1
-#^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^ comment.block.documentation.dart
+#       ^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *     code2
-#^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^ comment.block.documentation.dart
+#       ^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.documentation.dart
 > *     code3
-#^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^ comment.block.documentation.dart
+#       ^^^^^ comment.block.documentation.dart variable.other.source.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.documentation.dart
 > * ...
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^ comment.block.documentation.dart
 > */
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 >var blockDoc4;
-#^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#             ^ punctuation.terminator.dart
 >
 >/// ``
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^ comment.block.documentation.dart
 >var noInlineCode;
-#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#                ^ punctuation.terminator.dart
 >
 >/// `Stream<int>`
-#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^ comment.block.documentation.dart
+#    ^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >var inlineCode;
-#^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#              ^ punctuation.terminator.dart
 >
 >/// ` `
-#^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^ comment.block.documentation.dart
+#    ^^^ comment.block.documentation.dart variable.other.source.dart
 >var inlineCodeJustWhitespace;
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#                            ^ punctuation.terminator.dart
 >
 >/*
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.dart
 > * Old-style dartdoc
-#^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^ comment.block.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.dart
 > * ...
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^ comment.block.dart
 > */
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.dart
 >var b;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >/* Inline block comment */
-#^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
 >var c;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >/**
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 > * Nested block
-#^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.documentation.dart
 > * /**
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^ comment.block.documentation.dart
 > *  * Nested block
-#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *  */
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^ comment.block.documentation.dart
 > */
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 >var d;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >/**
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 > * Nested
-#^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^ comment.block.documentation.dart
 > *
-#^^ comment.block.documentation.dart variable.other.source.dart
+#^^ comment.block.documentation.dart
 > * /* Inline */
-#^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
+#   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
 > */
-#^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ comment.block.documentation.dart
 >var e;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >/* Nested /* Inline */ */
-#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
 >var f;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >// Simple comment
-#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
 >var g;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >/// Dartdoc with reference to [a].
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#                              ^^^ comment.block.documentation.dart variable.name.source.dart
+#                                 ^ comment.block.documentation.dart
 >/// And a link to [example.org](http://example.org/).
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
+#                               ^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 >var h;
-#^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ storage.type.primitive.dart
+#     ^ punctuation.terminator.dart
 >
 >class A<T /* comment */ > {
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^ keyword.declaration.dart
+#      ^ support.class.dart
+#       ^ other.source.dart
+#        ^ support.class.dart
+#          ^^^^^^^^^^^^^ comment.block.dart
+#                        ^ other.source.dart
 >  void b<T /* comment */ >() {}
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#  ^^^^ storage.type.primitive.dart
+#        ^ keyword.operator.comparison.dart
+#         ^ support.class.dart
+#           ^^^^^^^^^^^^^ comment.block.dart
+#                         ^ keyword.operator.comparison.dart
 >  Future<T /* comment */ > c() {}
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#  ^^^^^^ support.class.dart
+#        ^ other.source.dart
+#         ^ support.class.dart
+#           ^^^^^^^^^^^^^ comment.block.dart
+#                         ^ other.source.dart
+#                           ^ entity.name.function.dart
 >}
-#^ comment.block.documentation.dart variable.other.source.dart

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -2,14 +2,69 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Multiline dartdoc comment.
+/// Multiline dartdoc comment with triple backticks.
 ///
 /// ```
-/// doc
+/// code
 /// ```
 ///
 /// ...
-var a;
+var doc1;
+
+/// Multiline dartdoc comment with unclosed triple backticks.
+///
+/// ```
+/// code
+var doc2;
+
+/// Multiline dartdoc comment with unclosed backticks.
+///
+/// `code
+var doc3;
+
+/// Multiline dartdoc comment with indented code.
+///
+///     code1
+///     code2
+///
+///     code3
+///
+/// ...
+var doc4;
+
+/** Block dartdoc comment with triple backticks.
+ *
+ * ```
+ * code
+ * ```
+ *
+ * ...
+ */
+var blockDoc1;
+
+/** Block dartdoc comment with unclosed triple backticks.
+ *
+ * ```
+ * code
+ */
+var blockDoc2;
+
+/** Block dartdoc comment with unclosed backticks.
+ *
+ * `code
+ */
+var blockDoc3;
+
+/** Block dartdoc comment with indented code.
+ *
+ *     code1
+ *     code2
+ *
+ *     code3
+ *
+ * ...
+ */
+var blockDoc4;
 
 /// ``
 var noInlineCode;
@@ -56,7 +111,7 @@ var g;
 /// And a link to [example.org](http://example.org/).
 var h;
 
-class A<dynamic /* comment */ > {
-  void b<dynamic /* comment */ >() {}
-  Future<dynamic /* comment */ > c() {}
+class A<T /* comment */ > {
+  void b<T /* comment */ >() {}
+  Future<T /* comment */ > c() {}
 }


### PR DESCRIPTION
While investigating https://github.com/dart-lang/dart-syntax-highlight/issues/11 I found a difference in how VS Code and GitHub/linguist handle `when` in the grammars.

In VS Code, when a `when` pattern stops matching, any open scopes from nested rules are ended, whereas on GitHub they are not. This means an unterminated triple-backtick block on GitHub can escape out of the surrounding comment.

The discussion in https://github.com/github-linguist/linguist/issues/7015 concluded that VS Code's behaviour is incorrect, and GitHub's behaviour (to just keep processing the nested rules until they end before re-evaluating the `while`) matches TextMate.

Since this isn't well specified and it's not clear if VS Code will change behaviour to match, this change stops using `while` in the grammar and adjusts the `end` rules for the nested code blocks to detect when they are falling out of the comment (instead of assuming everything until the next triple-backticks is code.. which could be the entire file). It also fixes some issues where we didn't handle termination of block comments correctly either.

### Before changes:

![image](https://github.com/user-attachments/assets/587ebb27-c787-4dc0-9889-dde99e0ac71c)

Although that looks worse because the unclosed comment breaks the whole doc. Without that, the rest of the file before the changes looks like this:

![image](https://github.com/user-attachments/assets/58d940a9-d028-470a-befc-f07519fb45e9)

### After changes:

![image](https://github.com/user-attachments/assets/9377e970-259e-43f1-af69-113fc825ca60)

