### PR TITLE
Revert "Switch from using "while" to "end" and adjust nested rules accordingly"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 1.4.0 (2024-11-14)
-
-- Removed use of 'while' in the grammar to avoid some differences in implementations between GitHub and VS Code
-- Improved handling of unclosed code blocks in dartdoc comments
-
 ## 1.3.0 (2024-07-31)
 
 - Added support for digit separators (`_`).

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.4.0",
+	"version": "1.3.0",
 	"fileTypes": [
 		"dart"
 	],
@@ -69,16 +69,6 @@
 	],
 
 	"repository": {
-		"dartdoc-codeblock-triple": {
-			"begin": "^\\s*///\\s*(?!\\s*```)",
-			"end": "\n",
-			"contentName": "variable.other.source.dart"
-		},
-		"dartdoc-codeblock-block": {
-			"begin": "^\\s*\\*\\s*(?!(\\s*```|\/))",
-			"end": "\n",
-			"contentName": "variable.other.source.dart"
-		},
 		"dartdoc": {
 			"patterns": [
 				{
@@ -90,31 +80,30 @@
 					}
 				},
 				{
-					"begin": "^\\s*///\\s*(```)",
-					"end": "^\\s*///\\s*(```)|^(?!\\s*///)",
-					"patterns": [
-						{
-							"include": "#dartdoc-codeblock-triple"
-						}
-					]
-				},
-				{
-					"begin": "^\\s*\\*\\s*(```)",
-					"end": "^\\s*\\*\\s*(```)|^(?=\\s*\\*\/)",
-					"patterns": [
-						{
-							"include": "#dartdoc-codeblock-block"
-						}
-					]
-				},
-				{
-					"match": "`[^`\n]+`",
-					"name": "variable.other.source.dart"
-				},
-				{
-					"match": "\\s{4,}(.*)$",
+					"match": "^ {4,}(?![ \\*]).*",
 					"captures": {
-						"1": {
+						"0": {
+							"name": "variable.name.source.dart"
+						}
+					}
+				},
+				{
+					"contentName": "variable.other.source.dart",
+					"begin": "```.*?$",
+					"end": "```"
+				},
+				{
+					"match": "(`[^`]+?`)",
+					"captures": {
+						"0": {
+							"name": "variable.other.source.dart"
+						}
+					}
+				},
+				{
+					"match": "(\\* ((    ).*))$",
+					"captures": {
+						"2": {
 							"name": "variable.other.source.dart"
 						}
 					}
@@ -168,7 +157,7 @@
 				{
 					"name": "comment.block.documentation.dart",
 					"begin": "///",
-					"end": "^(?!\\s*///)",
+					"while": "^\\s*///",
 					"patterns": [
 						{
 							"include": "#dartdoc"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ environment:
   sdk: ^3.2.0
 
 dev_dependencies:
-  collection: ^1.19.0
-  dart_flutter_team_lints: ^3.2.1
+  collection: ^1.18.0
+  dart_flutter_team_lints: ^2.1.1
   path: ^1.9.0
-  string_scanner: ^1.4.0
-  test: ^1.25.8
+  string_scanner: ^1.2.0
+  test: ^1.25.2

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -5,143 +5,26 @@
 >// found in the LICENSE file.
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
 >
->/// Multiline dartdoc comment with triple backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>/// Multiline dartdoc comment.
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
->/// code
-#^^^^ comment.block.documentation.dart
-#    ^^^^ comment.block.documentation.dart variable.other.source.dart
+>/// doc
+#^^^ comment.block.documentation.dart
+#   ^^^^ comment.block.documentation.dart variable.other.source.dart
 >/// ```
-#^^^^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
+#   ^ comment.block.documentation.dart variable.other.source.dart
+#    ^^^ comment.block.documentation.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ...
 #^^^^^^^ comment.block.documentation.dart
->var doc1;
+>var a;
 #^^^ storage.type.primitive.dart
-#        ^ punctuation.terminator.dart
->
->/// Multiline dartdoc comment with unclosed triple backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
->///
-#^^^ comment.block.documentation.dart
->/// ```
-#^^^^^^^ comment.block.documentation.dart
->/// code
-#^^^^ comment.block.documentation.dart
-#    ^^^^ comment.block.documentation.dart variable.other.source.dart
->var doc2;
-#^^^ storage.type.primitive.dart
-#        ^ punctuation.terminator.dart
->
->/// Multiline dartdoc comment with unclosed backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
->///
-#^^^ comment.block.documentation.dart
->/// `code
-#^^^^^^^^^ comment.block.documentation.dart
->var doc3;
-#^^^ storage.type.primitive.dart
-#        ^ punctuation.terminator.dart
->
->/// Multiline dartdoc comment with indented code.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
->///
-#^^^ comment.block.documentation.dart
->///     code1
-#^^^^^^^^ comment.block.documentation.dart
-#        ^^^^^ comment.block.documentation.dart variable.other.source.dart
->///     code2
-#^^^^^^^^ comment.block.documentation.dart
-#        ^^^^^ comment.block.documentation.dart variable.other.source.dart
->///
-#^^^ comment.block.documentation.dart
->///     code3
-#^^^^^^^^ comment.block.documentation.dart
-#        ^^^^^ comment.block.documentation.dart variable.other.source.dart
->///
-#^^^ comment.block.documentation.dart
->/// ...
-#^^^^^^^ comment.block.documentation.dart
->var doc4;
-#^^^ storage.type.primitive.dart
-#        ^ punctuation.terminator.dart
->
->/** Block dartdoc comment with triple backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
-> *
-#^^ comment.block.documentation.dart
-> * ```
-#^^^^^^ comment.block.documentation.dart
-> * code
-#^^^ comment.block.documentation.dart
-#   ^^^^ comment.block.documentation.dart variable.other.source.dart
-> * ```
-#^^^^^^ comment.block.documentation.dart
-> *
-#^^ comment.block.documentation.dart
-> * ...
-#^^^^^^ comment.block.documentation.dart
-> */
-#^^^ comment.block.documentation.dart
->var blockDoc1;
-#^^^ storage.type.primitive.dart
-#             ^ punctuation.terminator.dart
->
->/** Block dartdoc comment with unclosed triple backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
-> *
-#^^ comment.block.documentation.dart
-> * ```
-#^^^^^^ comment.block.documentation.dart
-> * code
-#^^^ comment.block.documentation.dart
-#   ^^^^ comment.block.documentation.dart variable.other.source.dart
-> */
-#^^^ comment.block.documentation.dart
->var blockDoc2;
-#^^^ storage.type.primitive.dart
-#             ^ punctuation.terminator.dart
->
->/** Block dartdoc comment with unclosed backticks.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
-> *
-#^^ comment.block.documentation.dart
-> * `code
-#^^^^^^^^ comment.block.documentation.dart
-> */
-#^^^ comment.block.documentation.dart
->var blockDoc3;
-#^^^ storage.type.primitive.dart
-#             ^ punctuation.terminator.dart
->
->/** Block dartdoc comment with indented code.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
-> *
-#^^ comment.block.documentation.dart
-> *     code1
-#^^^^^^^ comment.block.documentation.dart
-#       ^^^^^ comment.block.documentation.dart variable.other.source.dart
-> *     code2
-#^^^^^^^ comment.block.documentation.dart
-#       ^^^^^ comment.block.documentation.dart variable.other.source.dart
-> *
-#^^ comment.block.documentation.dart
-> *     code3
-#^^^^^^^ comment.block.documentation.dart
-#       ^^^^^ comment.block.documentation.dart variable.other.source.dart
-> *
-#^^ comment.block.documentation.dart
-> * ...
-#^^^^^^ comment.block.documentation.dart
-> */
-#^^^ comment.block.documentation.dart
->var blockDoc4;
-#^^^ storage.type.primitive.dart
-#             ^ punctuation.terminator.dart
+#     ^ punctuation.terminator.dart
 >
 >/// ``
 #^^^^^^ comment.block.documentation.dart
@@ -240,24 +123,24 @@
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
 >
->class A<T /* comment */ > {
+>class A<dynamic /* comment */ > {
 #^^^^^ keyword.declaration.dart
 #      ^ support.class.dart
 #       ^ other.source.dart
-#        ^ support.class.dart
-#          ^^^^^^^^^^^^^ comment.block.dart
-#                        ^ other.source.dart
->  void b<T /* comment */ >() {}
+#        ^^^^^^^ support.class.dart
+#                ^^^^^^^^^^^^^ comment.block.dart
+#                              ^ other.source.dart
+>  void b<dynamic /* comment */ >() {}
 #  ^^^^ storage.type.primitive.dart
 #        ^ keyword.operator.comparison.dart
-#         ^ support.class.dart
-#           ^^^^^^^^^^^^^ comment.block.dart
-#                         ^ keyword.operator.comparison.dart
->  Future<T /* comment */ > c() {}
+#         ^^^^^^^ support.class.dart
+#                 ^^^^^^^^^^^^^ comment.block.dart
+#                               ^ keyword.operator.comparison.dart
+>  Future<dynamic /* comment */ > c() {}
 #  ^^^^^^ support.class.dart
 #        ^ other.source.dart
-#         ^ support.class.dart
-#           ^^^^^^^^^^^^^ comment.block.dart
-#                         ^ other.source.dart
-#                           ^ entity.name.function.dart
+#         ^^^^^^^ support.class.dart
+#                 ^^^^^^^^^^^^^ comment.block.dart
+#                               ^ other.source.dart
+#                                 ^ entity.name.function.dart
 >}

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -2,69 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Multiline dartdoc comment with triple backticks.
+/// Multiline dartdoc comment.
 ///
 /// ```
-/// code
+/// doc
 /// ```
 ///
 /// ...
-var doc1;
-
-/// Multiline dartdoc comment with unclosed triple backticks.
-///
-/// ```
-/// code
-var doc2;
-
-/// Multiline dartdoc comment with unclosed backticks.
-///
-/// `code
-var doc3;
-
-/// Multiline dartdoc comment with indented code.
-///
-///     code1
-///     code2
-///
-///     code3
-///
-/// ...
-var doc4;
-
-/** Block dartdoc comment with triple backticks.
- *
- * ```
- * code
- * ```
- *
- * ...
- */
-var blockDoc1;
-
-/** Block dartdoc comment with unclosed triple backticks.
- *
- * ```
- * code
- */
-var blockDoc2;
-
-/** Block dartdoc comment with unclosed backticks.
- *
- * `code
- */
-var blockDoc3;
-
-/** Block dartdoc comment with indented code.
- *
- *     code1
- *     code2
- *
- *     code3
- *
- * ...
- */
-var blockDoc4;
+var a;
 
 /// ``
 var noInlineCode;
@@ -111,7 +56,7 @@ var g;
 /// And a link to [example.org](http://example.org/).
 var h;
 
-class A<T /* comment */ > {
-  void b<T /* comment */ >() {}
-  Future<T /* comment */ > c() {}
+class A<dynamic /* comment */ > {
+  void b<dynamic /* comment */ >() {}
+  Future<dynamic /* comment */ > c() {}
 }


### PR DESCRIPTION
I re-found the bug mentioned at https://github.com/dart-lang/dart-syntax-highlight/pull/75#issuecomment-2449709951 just after merging, so I'm reverting that change.

This reverts dart-lang/dart-syntax-highlight#75

For my reference, we have some slightly different test files for the grammar in the Dart-Code repo, and it was one of those where the bug showed up:

![image](https://github.com/user-attachments/assets/fd6a3d6d-9f7e-4902-ae5d-a00a9e7bd9ab)
