### PR TITLE
Fix issue with indented closing block comment marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 1.4.0 (2024-11-14)
+## 1.4.1 (2024-11-18)
+
+- Fixed a bug where a closing block comment marker indented by more than 4 spaces would not end the comment.
+
+## 1.4.0 (2024-11-18)
 
 - Removed use of 'while' in the grammar to avoid some differences in implementations between GitHub and VS Code
 - Improved handling of unclosed code blocks in dartdoc comments

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"fileTypes": [
 		"dart"
 	],
@@ -112,7 +112,7 @@
 					"name": "variable.other.source.dart"
 				},
 				{
-					"match": "\\s{4,}(.*)$",
+					"match": "(?:\\*|\\/\\/)\\s{4,}(.*?)(?=($|\\*\\/))",
 					"captures": {
 						"1": {
 							"name": "variable.other.source.dart"

--- a/test/goldens/comments.dart.golden
+++ b/test/goldens/comments.dart.golden
@@ -203,6 +203,21 @@
 >
 >/**
 #^^^ comment.block.documentation.dart
+> *   /**
+#^^^^^^^^ comment.block.documentation.dart
+> *    * bbb
+#^^^^^^ comment.block.documentation.dart
+#      ^^^^^ comment.block.documentation.dart variable.other.source.dart
+> *    */
+#^^^^^^^^ comment.block.documentation.dart
+> */
+#^^^ comment.block.documentation.dart
+>var d2;
+#^^^ storage.type.primitive.dart
+#      ^ punctuation.terminator.dart
+>
+>/**
+#^^^ comment.block.documentation.dart
 > * Nested
 #^^^^^^^^^ comment.block.documentation.dart
 > *

--- a/test/test_files/comments.dart
+++ b/test/test_files/comments.dart
@@ -95,6 +95,13 @@ var c;
 var d;
 
 /**
+ *   /**
+ *    * bbb
+ *    */
+ */
+var d2;
+
+/**
  * Nested
  *
  * /* Inline */


### PR DESCRIPTION
This fixes the issue that was noted at https://github.com/dart-lang/dart-syntax-highlight/pull/75#issuecomment-2449709951 which was caused by an indented `*/` being considered part of a code block and not triggering the end of the comment.

![Screenshot 2024-11-18 103035](https://github.com/user-attachments/assets/cb038e1f-c674-4453-8241-5aec5e756929)

