### PR TITLE
Fix the patterns for code blocks and the handling of newlines when matching patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.6.0 (2026-07-28)
+
+- Improved handling of unclosed code blocks in doc comments.
+
 ## 1.5.0 (2026-02-23)
 
 - Improved handling of `new` and `factory`, including in syntax for Primary Constructors

--- a/grammars/dart.json
+++ b/grammars/dart.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"fileTypes": [
 		"dart"
 	],
@@ -77,12 +77,12 @@
 	"repository": {
 		"dartdoc-codeblock-triple": {
 			"begin": "^\\s*///\\s*(?!\\s*```)",
-			"end": "\n",
+			"end": "$",
 			"contentName": "variable.other.source.dart"
 		},
 		"dartdoc-codeblock-block": {
 			"begin": "^\\s*\\*\\s*(?!(\\s*```|\/))",
-			"end": "\n",
+			"end": "$",
 			"contentName": "variable.other.source.dart"
 		},
 		"dartdoc": {

--- a/test/goldens/unclosed_code_in_comments.dart.golden
+++ b/test/goldens/unclosed_code_in_comments.dart.golden
@@ -8,7 +8,9 @@
 >///                                                                             // Line 4
 #^^^ comment.block.documentation.dart
 >int? x1;                                                                        // Line 5
-#^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^ support.class.dart
+#   ^ keyword.operator.ternary.dart
+#       ^ punctuation.terminator.dart
 >
 >/// ```                                                                         // Line 7
 #^^^^^^^ comment.block.documentation.dart

--- a/test/goldens/unclosed_code_in_comments.dart.golden
+++ b/test/goldens/unclosed_code_in_comments.dart.golden
@@ -1,0 +1,43 @@
+>/// Text                                                                        // Line 1
+#^^^^^^^^ comment.block.documentation.dart
+>/// ```                                                                         // Line 2
+#^^^^^^^ comment.block.documentation.dart
+>/// code                                                                        // Line 3
+#^^^^ comment.block.documentation.dart
+#    ^^^^ comment.block.documentation.dart variable.other.source.dart
+>///                                                                             // Line 4
+#^^^ comment.block.documentation.dart
+>int? x1;                                                                        // Line 5
+#^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+>
+>/// ```                                                                         // Line 7
+#^^^^^^^ comment.block.documentation.dart
+>/// code                                                                        // Line 8
+#^^^^^^^^ comment.block.documentation.dart
+>///                                                                             // Line 9
+#^^^ comment.block.documentation.dart
+>int? x2;                                                                        // Line 10
+#^^^ support.class.dart
+#   ^ keyword.operator.ternary.dart
+#       ^ punctuation.terminator.dart
+>
+>/// Text                                                                        // Line 12
+#^^^^^^^^ comment.block.documentation.dart
+>/// ```                                                                         // Line 13
+#^^^^^^^ comment.block.documentation.dart
+>/// code                                                                        // Line 14
+#^^^^ comment.block.documentation.dart
+#    ^^^^ comment.block.documentation.dart variable.other.source.dart
+>int? x3;                                                                        // Line 15
+#^^^ support.class.dart
+#   ^ keyword.operator.ternary.dart
+#       ^ punctuation.terminator.dart
+>
+>/// ```                                                                         // Line 17
+#^^^^^^^ comment.block.documentation.dart
+>/// code                                                                        // Line 18
+#^^^^^^^^ comment.block.documentation.dart
+>int? x4;                                                                        // Line 19
+#^^^ support.class.dart
+#   ^ keyword.operator.ternary.dart
+#       ^ punctuation.terminator.dart

--- a/test/support/span_parser.dart
+++ b/test/support/span_parser.dart
@@ -130,13 +130,13 @@ class ScopeSpan {
     );
 
     while (!splitScanner.isDone) {
-      if (splitScanner.matches(cond)) {
+      if (splitScanner.matchesOnCurrentLine(cond)) {
         // Update the end position for this span as it's been fully processed.
         current._endLocation = splitScanner.location;
         splitSpans.add(current);
 
         // Move the scanner position past the matched condition.
-        splitScanner.scan(cond);
+        splitScanner.scanOnCurrentLine(cond);
 
         // Create a new span based on the current position.
         current = ScopeSpan(
@@ -274,7 +274,7 @@ class _SimpleMatcher extends GrammarMatcher {
   @override
   bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
     final location = scanner.location;
-    if (scanner.scan(match)) {
+    if (scanner.scanOnCurrentLine(match)) {
       scopeStack.push(name, location);
       _applyCapture(grammar, scanner, scopeStack, captures, location);
       scopeStack.pop(name, scanner.location);
@@ -363,7 +363,7 @@ class _MultilineMatcher extends GrammarMatcher {
 
   void _scanBegin(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
     final location = scanner.location;
-    if (!scanner.scan(begin)) {
+    if (!scanner.scanOnCurrentLine(begin)) {
       // This shouldn't happen since we've already checked that `begin` matches
       // the beginning of the string.
       throw StateError('Expected ${begin.pattern} to match.');
@@ -405,7 +405,7 @@ class _MultilineMatcher extends GrammarMatcher {
     LineScanner scanner,
     ScopeStack scopeStack,
   ) {
-    while (!scanner.isDone && end != null && !scanner.matches(end!)) {
+    while (!scanner.isDone && end != null && !scanner.matchesOnCurrentLine(end!)) {
       bool foundMatch = false;
       for (final pattern in patterns ?? <GrammarMatcher>[]) {
         if (pattern.scan(grammar, scanner, scopeStack)) {
@@ -422,7 +422,7 @@ class _MultilineMatcher extends GrammarMatcher {
 
   void _scanEnd(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
     final location = scanner.location;
-    if (end != null && !scanner.scan(end!)) {
+    if (end != null && !scanner.scanOnCurrentLine(end!)) {
       return;
     }
     _processCaptureHelper(grammar, scanner, scopeStack, endCaptures, location);
@@ -448,7 +448,7 @@ class _MultilineMatcher extends GrammarMatcher {
 
   @override
   bool scan(Grammar grammar, LineScanner scanner, ScopeStack scopeStack) {
-    if (!scanner.matches(begin)) {
+    if (!scanner.matchesOnCurrentLine(begin)) {
       return false;
     }
 
@@ -463,7 +463,7 @@ class _MultilineMatcher extends GrammarMatcher {
       // Find the range of the string that is matched by the while condition.
       final start = scanner.position;
       _skipLine(scanner);
-      while (!scanner.isDone && whileCond != null && scanner.scan(whileCond!)) {
+      while (!scanner.isDone && whileCond != null && scanner.scanOnCurrentLine(whileCond!)) {
         _skipLine(scanner);
       }
       final end = scanner.position;
@@ -484,7 +484,7 @@ class _MultilineMatcher extends GrammarMatcher {
       // Process each line until the `while` condition fails.
       while (!contentScanner.isDone &&
           whileCond != null &&
-          contentScanner.scan(whileCond!)) {
+          contentScanner.scanOnCurrentLine( whileCond!)) {
         _scanToEndOfLine(grammar, contentScanner, scopeStack);
       }
 
@@ -785,4 +785,32 @@ class ScopeStackLocation {
 extension LineScannerExtension on LineScanner {
   ScopeStackLocation get location =>
       ScopeStackLocation(position: position, line: line, column: column);
+
+  /// Returns whether [pattern] matches at the scanner's current position
+  /// without consuming a line break.
+  ///
+  /// Use this for all TextMate grammar regular expressions. The TextMate
+  /// [Language Rules documentation](https://macromates.com/manual/en/language_grammars#language_rules)
+  /// specifies that regular expressions are matched against one document line
+  /// at a time, while [LineScanner] searches the remaining source text. Without
+  /// this check, a pattern containing whitespace such as `\s*` can consume text
+  /// from the next line and produce scopes that TextMate would not.
+  bool matchesOnCurrentLine(RegExp pattern) {
+    if (!matches(pattern)) return false;
+
+    final match = lastMatch![0]!;
+    return !match.contains('\n') && !match.contains('\r');
+  }
+
+  /// Scans [pattern] only when it matches without consuming a line break.
+  ///
+  /// Use this instead of [LineScanner.scan] when consuming a TextMate grammar
+  /// regular expression. See [matchesOnCurrentLine] for the rule requiring
+  /// line-local matching. Use the scanner directly only for parser operations
+  /// that intentionally move across lines, such as skipping a physical line.
+  bool scanOnCurrentLine(RegExp pattern) {
+    if (!matchesOnCurrentLine(pattern)) return false;
+
+    return scan(pattern);
+  }
 }

--- a/test/test_files/unclosed_code_in_comments.dart
+++ b/test/test_files/unclosed_code_in_comments.dart
@@ -1,0 +1,19 @@
+/// Text
+/// ```
+/// code
+///
+int? x1;
+
+/// ```
+/// code
+///
+int? x2;
+
+/// Text
+/// ```
+/// code
+int? x3;
+
+/// ```
+/// code
+int? x4;


### PR DESCRIPTION
## Note for reviewers:

For convenience, I've pushed this PR in two commits:

1. Adds a new test file and the current golden for applying the existing grammar
2. Adds the fix, and updates the golden

This makes it easier to see the change to the golden from applying this fix, which is for the line after the comment to be correctly tokenized instead of being marked as a comment/code block:

```
>int? x1;                                                                        // Line 5
#^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
#^^^ support.class.dart
#   ^ keyword.operator.ternary.dart
#       ^ punctuation.terminator.dart
```

Note: The parser here is only used for tests, however it is a copy of the same file in DevTools (see https://github.com/flutter/devtools/pull/9921).

## Description:

TextMate grammars are matched by-line and therefore can never match `\n`. However our Dart implementation allowed this, which resulted in some bugs when code blocks are not closed.

This updates the grammar to instead use `$` to match the end of the line, and updates the parser to only ever match on the current line and not consumer the newline. With this change, the result matches the output of the TypeScript implementation used for testing in Dart-Code.

The parser is owned by the DevTools repo, and https://github.com/flutter/devtools/pull/9921 is the equivalent change there.

See https://github.com/Dart-Code/Dart-Code/issues/6130
See https://github.com/Dart-Code/Dart-Code/issues/6131
