### PR TITLE
Minimize required permissions on GH workflow

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,5 +1,8 @@
 name: Dart
 
+permissions:
+  contents: read
+
 on:
   schedule:
     # “At 00:00 (UTC) on Sunday.”
@@ -17,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
       - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260
         with:
           sdk: stable


### PR DESCRIPTION
Another PR (https://github.com/dart-lang/dart-syntax-highlight/pull/92) is failing because zizmor rejects using the default permissions.

This adds an explicit permission to only have access to read, plus also uses `persist-credentials: false` for checkouts (matching other updates along these lines, such as https://github.com/flutter/cocoon/pull/5106), which I believe should pass these checks.

(cc @pq)